### PR TITLE
feat: implement YAML configuration with secure password management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,13 @@ ratatui = "0.29"
 crossterm = "0.28"
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_yaml = "0.9"
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 dirs = "5.0"
 async-trait = "0.1"
+base64 = "0.22"
+ring = "0.17"
+
+[dev-dependencies]
+tempfile = "3.13"

--- a/docs/CONFIG_SECURITY.md
+++ b/docs/CONFIG_SECURITY.md
@@ -1,0 +1,196 @@
+# LazyDB 設定とセキュリティ
+
+## 概要
+
+LazyDBでは、データベース接続設定をYAMLファイルで管理します。パスワードは暗号化され、設定ファイルの肥大化を防ぐ工夫も施されています。
+
+## 設定ファイルの場所
+
+設定ファイルは `~/.config/lazydb/config.yaml` に保存されます。
+
+## セキュリティ機能
+
+### パスワードの暗号化
+
+パスワードは以下の方法で安全に保存されます：
+
+1. **PBKDF2-HMAC-SHA256**を使用してパスワードをハッシュ化
+2. **10万回の反復処理**でレインボーテーブル攻撃を防止
+3. **ランダムソルト**で同じパスワードでも異なるハッシュを生成
+4. **Base64エンコード**でYAMLに安全に保存
+
+```yaml
+secure_password:
+  salt: "ランダムに生成されたソルト（Base64）"
+  hash: "PBKDF2で生成されたハッシュ（Base64）"
+```
+
+### セキュリティの利点
+
+- **プレーンテキストなし**: パスワードは生データで保存されません
+- **リバースエンジニアリング困難**: ハッシュからパスワードを復元不可能
+- **ソルト使用**: 同じパスワードでも異なるハッシュになります
+- **高コスト**: 10万回の反復でブルートフォース攻撃を困難にします
+
+## 設定ファイルの構造
+
+### 基本的な接続設定
+
+```yaml
+connections:
+  - id: "unique_connection_id"
+    name: "表示名"
+    database_type: "PostgreSQL"  # PostgreSQL, MySQL, SQLite, MongoDB
+    host: "localhost"
+    port: 5432
+    username: "database_user"
+    database_name: "database_name"
+    # パスワードは実行時に設定され、暗号化されて保存されます
+    tags:
+      - "production"
+      - "primary"
+```
+
+### 肥大化防止の工夫
+
+#### 1. Connection Groups
+
+関連する接続をグループ化して整理：
+
+```yaml
+connection_groups:
+  - name: "Production"
+    description: "本番環境のデータベース"
+    connections:
+      - "postgres_prod"
+      - "mysql_prod"
+  
+  - name: "Development"
+    description: "開発環境のデータベース"
+    connections:
+      - "postgres_dev"
+      - "sqlite_local"
+```
+
+#### 2. Tags
+
+接続にタグを付けて分類：
+
+```yaml
+connections:
+  - id: "api_db"
+    name: "API Database"
+    # ...
+    tags:
+      - "api"
+      - "read-only"
+      - "cached"
+```
+
+#### 3. Projects
+
+複数の接続をプロジェクト単位で管理：
+
+```yaml
+projects:
+  - id: "web_app"
+    name: "Web Application"
+    connection_ids:
+      - "postgres_prod"
+      - "redis_cache"
+      - "analytics_db"
+```
+
+#### 4. オプショナルフィールド
+
+不要なフィールドは自動的に省略されます：
+
+- `secure_password`: パスワードが設定されていない場合
+- `database_name`: データベース名が不要な場合
+- `tags`: タグが設定されていない場合
+- `description`: 説明が設定されていない場合
+
+## 使用例
+
+### 1. 基本的な使用方法
+
+```rust
+use lazydb::config::{Config, Connection, DatabaseType};
+
+// 設定をロード
+let mut config = Config::load()?;
+
+// 新しい接続を作成
+let mut connection = Connection::new(
+    "my_db".to_string(),
+    "My Database".to_string(),
+    DatabaseType::PostgreSQL,
+    "localhost".to_string(),
+    5432,
+    "user".to_string(),
+    Some("mydb".to_string()),
+);
+
+// パスワードを安全に設定
+connection.set_password("my_secret_password")?;
+
+// 設定に追加
+config.add_connection(connection);
+
+// 設定を保存
+config.save()?;
+```
+
+### 2. パスワード検証
+
+```rust
+// パスワードの確認
+let is_valid = connection.verify_password("my_secret_password")?;
+assert!(is_valid);
+
+// 間違ったパスワード
+let is_invalid = connection.verify_password("wrong_password")?;
+assert!(!is_invalid);
+```
+
+### 3. 設定の検証
+
+```rust
+// 設定の整合性をチェック
+config.validate()?;
+```
+
+## 設定ファイルの例
+
+完全な設定例は `config_example.yaml` を参照してください。
+
+## セキュリティのベストプラクティス
+
+1. **定期的なパスワード変更**: セキュアハッシュを使用していても定期更新を推奨
+2. **ファイル権限**: 設定ファイルのアクセス権限を適切に設定（`chmod 600`）
+3. **バックアップ**: 設定ファイルのセキュアなバックアップを作成
+4. **バージョン管理除外**: `.gitignore`に設定ファイルを追加
+
+## トラブルシューティング
+
+### YAML解析エラー
+
+```bash
+# 設定ファイルの構文チェック
+yamllint ~/.config/lazydb/config.yaml
+```
+
+### パスワード検証失敗
+
+パスワードの検証に失敗する場合：
+1. パスワードを再設定
+2. 設定ファイルを再生成
+3. キャッシュをクリア
+
+### ファイル権限エラー
+
+```bash
+# 設定ディレクトリの権限を修正
+chmod 700 ~/.config/lazydb
+chmod 600 ~/.config/lazydb/config.yaml
+```

--- a/docs/config_example.yaml
+++ b/docs/config_example.yaml
@@ -1,0 +1,78 @@
+# LazyDB Configuration Example
+# This file demonstrates the YAML configuration structure for database connections
+
+connections:
+  - id: "postgres_prod"
+    name: "Production PostgreSQL"
+    database_type: "PostgreSQL"
+    host: "prod-db.example.com"
+    port: 5432
+    username: "app_user"
+    database_name: "production_db"
+    # パスワードは暗号化されて保存されます (secure_password フィールド)
+    tags:
+      - "production"
+      - "primary"
+
+  - id: "mysql_dev"
+    name: "Development MySQL"
+    database_type: "MySQL"
+    host: "localhost"
+    port: 3306
+    username: "dev_user"
+    database_name: "dev_db"
+    tags:
+      - "development"
+      - "local"
+
+  - id: "sqlite_local"
+    name: "Local SQLite"
+    database_type: "SQLite"
+    host: "localhost"
+    port: 0  # SQLiteでは不要
+    username: ""  # SQLiteでは不要
+    database_name: "./data/local.db"
+    tags:
+      - "local"
+      - "file-based"
+
+  - id: "mongo_cluster"
+    name: "MongoDB Cluster"
+    database_type: "MongoDB"
+    host: "cluster.mongodb.example.com"
+    port: 27017
+    username: "mongo_user"
+    database_name: "app_database"
+    tags:
+      - "nosql"
+      - "cluster"
+
+projects:
+  - id: "web_app"
+    name: "Web Application"
+    connection_ids:
+      - "postgres_prod"
+      - "mysql_dev"
+
+  - id: "analytics"
+    name: "Analytics Project"
+    connection_ids:
+      - "mongo_cluster"
+      - "sqlite_local"
+
+# Connection groups help organize connections (prevents file bloat)
+connection_groups:
+  - name: "Production"
+    description: "Production environment databases"
+    connections:
+      - "postgres_prod"
+      - "mongo_cluster"
+
+  - name: "Development"
+    description: "Development and testing databases"
+    connections:
+      - "mysql_dev"
+      - "sqlite_local"
+
+# Default group to show when app starts
+default_connection_group: "Development"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,10 +1,20 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+mod security;
+pub use security::{PasswordManager, SecurePassword};
+
+#[cfg(test)]
+mod tests;
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
     pub connections: Vec<Connection>,
     pub projects: Vec<Project>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub connection_groups: Vec<ConnectionGroup>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_connection_group: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -16,8 +26,17 @@ pub struct Connection {
     pub port: u16,
     pub username: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub password: Option<String>,
+    pub secure_password: Option<SecurePassword>,
     pub database_name: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ConnectionGroup {
+    pub name: String,
+    pub connections: Vec<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -41,7 +60,7 @@ impl Config {
         
         if config_path.exists() {
             let content = std::fs::read_to_string(&config_path)?;
-            let config: Config = serde_json::from_str(&content)?;
+            let config: Config = serde_yaml::from_str(&content)?;
             Ok(config)
         } else {
             let config = Self::default();
@@ -50,6 +69,7 @@ impl Config {
         }
     }
 
+
     pub fn save(&self) -> anyhow::Result<()> {
         let config_path = Self::config_path()?;
         
@@ -57,7 +77,7 @@ impl Config {
             std::fs::create_dir_all(parent)?;
         }
         
-        let content = serde_json::to_string_pretty(self)?;
+        let content = serde_yaml::to_string(self)?;
         std::fs::write(&config_path, content)?;
         
         Ok(())
@@ -67,7 +87,7 @@ impl Config {
         let config_dir = dirs::config_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?;
         
-        Ok(config_dir.join("lazydb").join("config.json"))
+        Ok(config_dir.join("lazydb").join("config.yaml"))
     }
 
     pub fn add_connection(&mut self, connection: Connection) {
@@ -77,6 +97,22 @@ impl Config {
     pub fn add_project(&mut self, project: Project) {
         self.projects.push(project);
     }
+
+    pub fn add_connection_group(&mut self, group: ConnectionGroup) {
+        self.connection_groups.push(group);
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        for connection in &self.connections {
+            connection.validate()?;
+        }
+        
+        for group in &self.connection_groups {
+            group.validate(&self.connections)?;
+        }
+        
+        Ok(())
+    }
 }
 
 impl Default for Config {
@@ -84,6 +120,96 @@ impl Default for Config {
         Self {
             connections: Vec::new(),
             projects: Vec::new(),
+            connection_groups: Vec::new(),
+            default_connection_group: None,
         }
+    }
+}
+
+impl Connection {
+    pub fn new(
+        id: String,
+        name: String,
+        database_type: DatabaseType,
+        host: String,
+        port: u16,
+        username: String,
+        database_name: Option<String>,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            database_type,
+            host,
+            port,
+            username,
+            secure_password: None,
+            database_name,
+            tags: Vec::new(),
+        }
+    }
+
+    pub fn set_password(&mut self, password: &str) -> anyhow::Result<()> {
+        self.secure_password = Some(PasswordManager::encrypt_password(password)?);
+        Ok(())
+    }
+
+    pub fn verify_password(&self, password: &str) -> anyhow::Result<bool> {
+        match &self.secure_password {
+            Some(secure_password) => PasswordManager::verify_password(password, secure_password),
+            None => Ok(false),
+        }
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.id.is_empty() {
+            return Err(anyhow::anyhow!("Connection ID cannot be empty"));
+        }
+        
+        if self.name.is_empty() {
+            return Err(anyhow::anyhow!("Connection name cannot be empty"));
+        }
+        
+        if self.host.is_empty() {
+            return Err(anyhow::anyhow!("Host cannot be empty"));
+        }
+        
+        if self.port == 0 {
+            return Err(anyhow::anyhow!("Port must be greater than 0"));
+        }
+        
+        if self.username.is_empty() {
+            return Err(anyhow::anyhow!("Username cannot be empty"));
+        }
+        
+        Ok(())
+    }
+}
+
+impl ConnectionGroup {
+    pub fn new(name: String, connections: Vec<String>) -> Self {
+        Self {
+            name,
+            connections,
+            description: None,
+        }
+    }
+
+    pub fn validate(&self, all_connections: &[Connection]) -> anyhow::Result<()> {
+        if self.name.is_empty() {
+            return Err(anyhow::anyhow!("Connection group name cannot be empty"));
+        }
+
+        for connection_id in &self.connections {
+            if !all_connections.iter().any(|c| &c.id == connection_id) {
+                return Err(anyhow::anyhow!(
+                    "Connection group '{}' references non-existent connection '{}'",
+                    self.name,
+                    connection_id
+                ));
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/config/security.rs
+++ b/src/config/security.rs
@@ -1,0 +1,91 @@
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose, Engine as _};
+use ring::{digest, pbkdf2};
+use serde::{Deserialize, Serialize};
+use std::num::NonZeroU32;
+
+const CREDENTIAL_LEN: usize = digest::SHA256_OUTPUT_LEN;
+const SALT_LEN: usize = 16;
+const PBKDF2_ITERATIONS: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(100_000) };
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecurePassword {
+    pub salt: String,
+    pub hash: String,
+}
+
+pub struct PasswordManager;
+
+impl PasswordManager {
+    pub fn encrypt_password(password: &str) -> Result<SecurePassword> {
+        let salt = Self::generate_salt();
+        let hash = Self::derive_key(password, &salt)?;
+        
+        Ok(SecurePassword {
+            salt: general_purpose::STANDARD.encode(&salt),
+            hash: general_purpose::STANDARD.encode(&hash),
+        })
+    }
+
+    pub fn verify_password(password: &str, secure_password: &SecurePassword) -> Result<bool> {
+        let salt = general_purpose::STANDARD.decode(&secure_password.salt)?;
+        let expected_hash = general_purpose::STANDARD.decode(&secure_password.hash)?;
+        
+        let actual_hash = Self::derive_key(password, &salt)?;
+        
+        Ok(actual_hash == expected_hash)
+    }
+
+    fn generate_salt() -> Vec<u8> {
+        use ring::rand::{SecureRandom, SystemRandom};
+        
+        let rng = SystemRandom::new();
+        let mut salt = vec![0u8; SALT_LEN];
+        rng.fill(&mut salt).expect("Failed to generate random salt");
+        salt
+    }
+
+    fn derive_key(password: &str, salt: &[u8]) -> Result<Vec<u8>> {
+        let mut derived_key = vec![0u8; CREDENTIAL_LEN];
+        
+        pbkdf2::derive(
+            pbkdf2::PBKDF2_HMAC_SHA256,
+            PBKDF2_ITERATIONS,
+            salt,
+            password.as_bytes(),
+            &mut derived_key,
+        );
+        
+        Ok(derived_key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_password_encryption_and_verification() {
+        let password = "test_password_123";
+        
+        let secure_password = PasswordManager::encrypt_password(password).unwrap();
+        
+        assert!(PasswordManager::verify_password(password, &secure_password).unwrap());
+        
+        assert!(!PasswordManager::verify_password("wrong_password", &secure_password).unwrap());
+    }
+
+    #[test]
+    fn test_different_salts_produce_different_hashes() {
+        let password = "same_password";
+        
+        let secure1 = PasswordManager::encrypt_password(password).unwrap();
+        let secure2 = PasswordManager::encrypt_password(password).unwrap();
+        
+        assert_ne!(secure1.salt, secure2.salt);
+        assert_ne!(secure1.hash, secure2.hash);
+        
+        assert!(PasswordManager::verify_password(password, &secure1).unwrap());
+        assert!(PasswordManager::verify_password(password, &secure2).unwrap());
+    }
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,0 +1,158 @@
+#[cfg(test)]
+mod tests {
+    use crate::config::{Config, Connection, ConnectionGroup, DatabaseType};
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_yaml_config_serialization() {
+        let mut config = Config::default();
+
+        let mut connection = Connection::new(
+            "test_id".to_string(),
+            "Test Connection".to_string(),
+            DatabaseType::PostgreSQL,
+            "localhost".to_string(),
+            5432,
+            "test_user".to_string(),
+            Some("test_db".to_string()),
+        );
+
+        connection.set_password("secret_password").unwrap();
+        connection.tags = vec!["test".to_string(), "local".to_string()];
+
+        config.add_connection(connection);
+
+        let group = ConnectionGroup {
+            name: "Test Group".to_string(),
+            connections: vec!["test_id".to_string()],
+            description: Some("Test description".to_string()),
+        };
+        config.add_connection_group(group);
+
+        config.default_connection_group = Some("Test Group".to_string());
+
+        let yaml_content = serde_yaml::to_string(&config).unwrap();
+        println!("YAML output:\n{}", yaml_content);
+
+        let deserialized: Config = serde_yaml::from_str(&yaml_content).unwrap();
+        
+        assert_eq!(deserialized.connections.len(), 1);
+        assert_eq!(deserialized.connections[0].id, "test_id");
+        assert_eq!(deserialized.connections[0].name, "Test Connection");
+        assert_eq!(deserialized.connections[0].tags.len(), 2);
+        assert!(deserialized.connections[0].secure_password.is_some());
+
+        assert_eq!(deserialized.connection_groups.len(), 1);
+        assert_eq!(deserialized.connection_groups[0].name, "Test Group");
+        assert_eq!(deserialized.default_connection_group, Some("Test Group".to_string()));
+    }
+
+    #[test]
+    fn test_password_security() {
+        let mut connection = Connection::new(
+            "test_id".to_string(),
+            "Test Connection".to_string(),
+            DatabaseType::PostgreSQL,
+            "localhost".to_string(),
+            5432,
+            "test_user".to_string(),
+            None,
+        );
+
+        let password = "my_secret_password_123";
+        connection.set_password(password).unwrap();
+
+        assert!(connection.verify_password(password).unwrap());
+        assert!(!connection.verify_password("wrong_password").unwrap());
+
+        let yaml_content = serde_yaml::to_string(&connection).unwrap();
+        assert!(!yaml_content.contains(password));
+        println!("Secure connection YAML:\n{}", yaml_content);
+    }
+
+    #[test]
+    fn test_config_validation() {
+        let mut config = Config::default();
+        assert!(config.validate().is_ok());
+
+        let invalid_connection = Connection {
+            id: "".to_string(),
+            name: "Valid Name".to_string(),
+            database_type: DatabaseType::PostgreSQL,
+            host: "localhost".to_string(),
+            port: 5432,
+            username: "user".to_string(),
+            secure_password: None,
+            database_name: None,
+            tags: Vec::new(),
+        };
+        config.add_connection(invalid_connection);
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_connection_group_validation() {
+        let mut config = Config::default();
+
+        let connection = Connection::new(
+            "valid_id".to_string(),
+            "Valid Connection".to_string(),
+            DatabaseType::PostgreSQL,
+            "localhost".to_string(),
+            5432,
+            "user".to_string(),
+            None,
+        );
+        config.add_connection(connection);
+
+        let invalid_group = ConnectionGroup {
+            name: "Test Group".to_string(),
+            connections: vec!["nonexistent_id".to_string()],
+            description: None,
+        };
+        config.add_connection_group(invalid_group);
+
+        assert!(config.validate().is_err());
+
+        config.connection_groups.clear();
+        let valid_group = ConnectionGroup {
+            name: "Test Group".to_string(),
+            connections: vec!["valid_id".to_string()],
+            description: None,
+        };
+        config.add_connection_group(valid_group);
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_yaml_file_operations() {
+        let temp_dir = tempdir().unwrap();
+        let config_path = temp_dir.path().join("test_config.yaml");
+
+        let mut config = Config::default();
+        let mut connection = Connection::new(
+            "file_test".to_string(),
+            "File Test Connection".to_string(),
+            DatabaseType::MySQL,
+            "localhost".to_string(),
+            3306,
+            "test_user".to_string(),
+            Some("test_db".to_string()),
+        );
+        connection.set_password("file_test_password").unwrap();
+        config.add_connection(connection);
+
+        let yaml_content = serde_yaml::to_string(&config).unwrap();
+        fs::write(&config_path, yaml_content).unwrap();
+
+        let loaded_content = fs::read_to_string(&config_path).unwrap();
+        let loaded_config: Config = serde_yaml::from_str(&loaded_content).unwrap();
+
+        assert_eq!(loaded_config.connections.len(), 1);
+        assert_eq!(loaded_config.connections[0].id, "file_test");
+        assert!(loaded_config.connections[0].verify_password("file_test_password").unwrap());
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements YAML-based configuration management with secure password storage for LazyDB. The changes replace JSON configuration with YAML and add comprehensive security features to protect database credentials.

### Key Features

- **YAML Configuration**: Replace JSON with YAML for better readability and maintainability
- **Secure Password Management**: Implement PBKDF2-HMAC-SHA256 encryption for database passwords
- **Configuration Organization**: Add connection groups and tags to prevent config file bloat
- **Comprehensive Validation**: Add validation for connections and groups
- **Documentation**: Complete security documentation and configuration examples

### Security Implementation

- 🔐 **PBKDF2-HMAC-SHA256** with 100,000 iterations for password hashing
- 🧂 **Random salt generation** for each password to prevent rainbow table attacks
- 📁 **Base64 encoding** for safe YAML storage
- 🚫 **No plaintext passwords** stored in configuration files

### Configuration Structure

```yaml
connections:
  - id: "unique_id"
    name: "Display Name"
    database_type: "PostgreSQL"
    host: "localhost"
    port: 5432
    username: "user"
    # Password encrypted and stored as secure_password
    tags: ["production", "primary"]

connection_groups:
  - name: "Production"
    description: "Production databases"
    connections: ["unique_id"]
```

### Files Changed

- `Cargo.toml`: Added security dependencies (ring, base64, serde_yaml)
- `src/config/mod.rs`: Updated for YAML support and secure password management
- `src/config/security.rs`: New password encryption/verification module
- `src/config/tests.rs`: Comprehensive test suite
- `docs/CONFIG_SECURITY.md`: Security documentation
- `docs/config_example.yaml`: Configuration example

### Test Coverage

All security features are thoroughly tested:
- Password encryption and verification
- YAML serialization/deserialization
- Configuration validation
- File operations

🤖 Generated with [Claude Code](https://claude.ai/code)