### PR TITLE
feat: implement vim-style pane navigation with focus management

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,10 @@
 pub mod state;
 
-pub use state::{App, ViewState};
+pub use state::{
+    App, 
+    ViewState, 
+    ConnectionListPane, 
+    DatabaseExplorerPane, 
+    QueryEditorPane, 
+    Direction
+};

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -164,8 +164,8 @@ impl App {
                             }
                         }
                         Direction::Down => {
-                            // Use actual structure list length
-                            if self.database_explorer_state.structure_list_index < self.database_explorer_state.structure_list.len().saturating_sub(1) {
+                            // TODO: Use actual structure list length
+                            if self.database_explorer_state.structure_list_index < 5 {
                                 self.database_explorer_state.structure_list_index += 1;
                             }
                         }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -164,8 +164,8 @@ impl App {
                             }
                         }
                         Direction::Down => {
-                            // TODO: Use actual structure list length
-                            if self.database_explorer_state.structure_list_index < 5 {
+                            // Use actual structure list length
+                            if self.database_explorer_state.structure_list_index < self.database_explorer_state.structure_list.len().saturating_sub(1) {
                                 self.database_explorer_state.structure_list_index += 1;
                             }
                         }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -5,13 +5,52 @@ pub struct App {
     pub config: Config,
     pub should_quit: bool,
     pub current_view: ViewState,
+    pub connection_list_state: ConnectionListState,
+    pub database_explorer_state: DatabaseExplorerState,
+    pub query_editor_state: QueryEditorState,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ViewState {
     ConnectionList,
     DatabaseExplorer,
     QueryEditor,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConnectionListState {
+    pub focused_pane: ConnectionListPane,
+    pub projects_list_index: usize,
+    pub connections_list_index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConnectionListPane {
+    Projects,
+    Connections,
+}
+
+#[derive(Debug, Clone)]
+pub struct DatabaseExplorerState {
+    pub focused_pane: DatabaseExplorerPane,
+    pub structure_list_index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DatabaseExplorerPane {
+    Structure,
+    Content,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryEditorState {
+    pub focused_pane: QueryEditorPane,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryEditorPane {
+    Editor,
+    Results,
 }
 
 impl App {
@@ -22,6 +61,18 @@ impl App {
             config,
             should_quit: false,
             current_view: ViewState::ConnectionList,
+            connection_list_state: ConnectionListState {
+                focused_pane: ConnectionListPane::Projects,
+                projects_list_index: 0,
+                connections_list_index: 0,
+            },
+            database_explorer_state: DatabaseExplorerState {
+                focused_pane: DatabaseExplorerPane::Structure,
+                structure_list_index: 0,
+            },
+            query_editor_state: QueryEditorState {
+                focused_pane: QueryEditorPane::Editor,
+            },
         })
     }
 
@@ -31,5 +82,108 @@ impl App {
 
     pub fn switch_view(&mut self, view: ViewState) {
         self.current_view = view;
+        // Reset focus to first pane when switching view
+        match view {
+            ViewState::ConnectionList => {
+                self.connection_list_state.focused_pane = ConnectionListPane::Projects;
+            }
+            ViewState::DatabaseExplorer => {
+                self.database_explorer_state.focused_pane = DatabaseExplorerPane::Structure;
+            }
+            ViewState::QueryEditor => {
+                self.query_editor_state.focused_pane = QueryEditorPane::Editor;
+            }
+        }
     }
+
+    pub fn move_focus_next_pane(&mut self) {
+        match self.current_view {
+            ViewState::ConnectionList => {
+                self.connection_list_state.focused_pane = match self.connection_list_state.focused_pane {
+                    ConnectionListPane::Projects => ConnectionListPane::Connections,
+                    ConnectionListPane::Connections => ConnectionListPane::Projects,
+                };
+            }
+            ViewState::DatabaseExplorer => {
+                self.database_explorer_state.focused_pane = match self.database_explorer_state.focused_pane {
+                    DatabaseExplorerPane::Structure => DatabaseExplorerPane::Content,
+                    DatabaseExplorerPane::Content => DatabaseExplorerPane::Structure,
+                };
+            }
+            ViewState::QueryEditor => {
+                self.query_editor_state.focused_pane = match self.query_editor_state.focused_pane {
+                    QueryEditorPane::Editor => QueryEditorPane::Results,
+                    QueryEditorPane::Results => QueryEditorPane::Editor,
+                };
+            }
+        }
+    }
+
+    pub fn move_within_pane(&mut self, direction: Direction) {
+        match self.current_view {
+            ViewState::ConnectionList => {
+                match self.connection_list_state.focused_pane {
+                    ConnectionListPane::Projects => {
+                        match direction {
+                            Direction::Up => {
+                                if self.connection_list_state.projects_list_index > 0 {
+                                    self.connection_list_state.projects_list_index -= 1;
+                                }
+                            }
+                            Direction::Down => {
+                                if self.connection_list_state.projects_list_index < self.config.projects.len().saturating_sub(1) {
+                                    self.connection_list_state.projects_list_index += 1;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    ConnectionListPane::Connections => {
+                        match direction {
+                            Direction::Up => {
+                                if self.connection_list_state.connections_list_index > 0 {
+                                    self.connection_list_state.connections_list_index -= 1;
+                                }
+                            }
+                            Direction::Down => {
+                                if self.connection_list_state.connections_list_index < self.config.connections.len().saturating_sub(1) {
+                                    self.connection_list_state.connections_list_index += 1;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            ViewState::DatabaseExplorer => {
+                if self.database_explorer_state.focused_pane == DatabaseExplorerPane::Structure {
+                    match direction {
+                        Direction::Up => {
+                            if self.database_explorer_state.structure_list_index > 0 {
+                                self.database_explorer_state.structure_list_index -= 1;
+                            }
+                        }
+                        Direction::Down => {
+                            // TODO: Use actual structure list length
+                            if self.database_explorer_state.structure_list_index < 5 {
+                                self.database_explorer_state.structure_list_index += 1;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            ViewState::QueryEditor => {
+                // Query editor movement will be handled separately
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
 }

--- a/src/config/security.rs
+++ b/src/config/security.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use base64::{engine::general_purpose, Engine as _};
 use ring::{digest, pbkdf2};
 use serde::{Deserialize, Serialize};

--- a/src/ui/components/connection_list.rs
+++ b/src/ui/components/connection_list.rs
@@ -1,4 +1,4 @@
-use crate::app::App;
+use crate::app::{App, ConnectionListPane};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -25,17 +25,32 @@ fn render_projects_list(frame: &mut Frame, area: Rect, app: &App) {
         })
         .collect();
 
+    let is_focused = app.connection_list_state.focused_pane == ConnectionListPane::Projects;
+    let border_style = if is_focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::White)
+    };
+
+    let title = "Projects";
+
     let projects_list = List::new(projects)
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title("Projects")
+                .title(title)
+                .border_style(border_style)
         )
         .style(Style::default().fg(Color::White))
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol(">> ");
 
-    frame.render_widget(projects_list, area);
+    let mut state = ListState::default();
+    if is_focused {
+        state.select(Some(app.connection_list_state.projects_list_index));
+    }
+
+    frame.render_stateful_widget(projects_list, area, &mut state);
 }
 
 fn render_connections_list(frame: &mut Frame, area: Rect, app: &App) {
@@ -54,15 +69,30 @@ fn render_connections_list(frame: &mut Frame, area: Rect, app: &App) {
         })
         .collect();
 
+    let is_focused = app.connection_list_state.focused_pane == ConnectionListPane::Connections;
+    let border_style = if is_focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::White)
+    };
+
+    let title = "Connections";
+
     let connections_list = List::new(connections)
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title("Connections")
+                .title(title)
+                .border_style(border_style)
         )
         .style(Style::default().fg(Color::White))
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol(">> ");
 
-    frame.render_widget(connections_list, area);
+    let mut state = ListState::default();
+    if is_focused {
+        state.select(Some(app.connection_list_state.connections_list_index));
+    }
+
+    frame.render_stateful_widget(connections_list, area, &mut state);
 }

--- a/src/ui/components/database_explorer.rs
+++ b/src/ui/components/database_explorer.rs
@@ -1,4 +1,4 @@
-use crate::app::App;
+use crate::app::{App, DatabaseExplorerPane};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -15,7 +15,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     render_table_content(frame, chunks[1], app);
 }
 
-fn render_database_structure(frame: &mut Frame, area: Rect, _app: &App) {
+fn render_database_structure(frame: &mut Frame, area: Rect, app: &App) {
     let database_structure = List::new(vec![
         ListItem::new("📁 Tables"),
         ListItem::new("  📋 users"),
@@ -23,25 +23,52 @@ fn render_database_structure(frame: &mut Frame, area: Rect, _app: &App) {
         ListItem::new("  📋 comments"),
         ListItem::new("📁 Views"),
         ListItem::new("📁 Procedures"),
-    ])
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title("Database Structure")
-    )
-    .style(Style::default().fg(Color::White))
-    .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
-    .highlight_symbol(">> ");
+    ]);
 
-    frame.render_widget(database_structure, area);
+    let is_focused = app.database_explorer_state.focused_pane == DatabaseExplorerPane::Structure;
+    let border_style = if is_focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::White)
+    };
+
+    let title = "Database Structure";
+
+    let database_structure = database_structure
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .border_style(border_style)
+        )
+        .style(Style::default().fg(Color::White))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .highlight_symbol(">> ");
+
+    let mut state = ListState::default();
+    if is_focused {
+        state.select(Some(app.database_explorer_state.structure_list_index));
+    }
+
+    frame.render_stateful_widget(database_structure, area, &mut state);
 }
 
-fn render_table_content(frame: &mut Frame, area: Rect, _app: &App) {
+fn render_table_content(frame: &mut Frame, area: Rect, app: &App) {
+    let is_focused = app.database_explorer_state.focused_pane == DatabaseExplorerPane::Content;
+    let border_style = if is_focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::White)
+    };
+
+    let title = "Table Content";
+
     let table_content = Paragraph::new("Select a table to view its content")
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title("Table Content")
+                .title(title)
+                .border_style(border_style)
         )
         .style(Style::default().fg(Color::Gray))
         .alignment(Alignment::Center);

--- a/src/ui/components/query_editor.rs
+++ b/src/ui/components/query_editor.rs
@@ -1,8 +1,8 @@
-use crate::app::App;
+use crate::app::{App, QueryEditorPane};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
-pub fn render(frame: &mut Frame, area: Rect, _app: &App) {
+pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -11,16 +11,26 @@ pub fn render(frame: &mut Frame, area: Rect, _app: &App) {
         ])
         .split(area);
 
-    render_query_input(frame, chunks[0]);
-    render_query_results(frame, chunks[1]);
+    render_query_input(frame, chunks[0], app);
+    render_query_results(frame, chunks[1], app);
 }
 
-fn render_query_input(frame: &mut Frame, area: Rect) {
+fn render_query_input(frame: &mut Frame, area: Rect, app: &App) {
+    let is_focused = app.query_editor_state.focused_pane == QueryEditorPane::Editor;
+    let border_style = if is_focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::White)
+    };
+
+    let title = "Query Editor";
+
     let query_input = Paragraph::new("SELECT * FROM users WHERE id = 1;")
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title("Query Editor")
+                .title(title)
+                .border_style(border_style)
         )
         .style(Style::default().fg(Color::White))
         .wrap(Wrap { trim: true });
@@ -28,12 +38,22 @@ fn render_query_input(frame: &mut Frame, area: Rect) {
     frame.render_widget(query_input, area);
 }
 
-fn render_query_results(frame: &mut Frame, area: Rect) {
+fn render_query_results(frame: &mut Frame, area: Rect, app: &App) {
+    let is_focused = app.query_editor_state.focused_pane == QueryEditorPane::Results;
+    let border_style = if is_focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::White)
+    };
+
+    let title = "Results";
+
     let query_results = Paragraph::new("Query results will appear here...")
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title("Results")
+                .title(title)
+                .border_style(border_style)
         )
         .style(Style::default().fg(Color::Gray))
         .alignment(Alignment::Center);

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -9,16 +9,16 @@ pub fn handle_events(app: &mut App) -> anyhow::Result<()> {
                 if key_event.modifiers.contains(KeyModifiers::CONTROL) {
                     match key_event.code {
                         KeyCode::Char('h') | KeyCode::Left => {
-                            app.move_focus_pane(Direction::Left);
+                            app.move_focus_next_pane();
                         }
                         KeyCode::Char('j') | KeyCode::Down => {
-                            app.move_focus_pane(Direction::Down);
+                            app.move_focus_next_pane();
                         }
                         KeyCode::Char('k') | KeyCode::Up => {
-                            app.move_focus_pane(Direction::Up);
+                            app.move_focus_next_pane();
                         }
                         KeyCode::Char('l') | KeyCode::Right => {
-                            app.move_focus_pane(Direction::Right);
+                            app.move_focus_next_pane();
                         }
                         _ => {}
                     }

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1,24 +1,57 @@
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
-use crate::app::{App, ViewState};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crate::app::{App, ViewState, Direction};
 
 pub fn handle_events(app: &mut App) -> anyhow::Result<()> {
     if event::poll(std::time::Duration::from_millis(50))? {
         if let Event::Key(key_event) = event::read()? {
             if key_event.kind == KeyEventKind::Press {
-                match key_event.code {
-                    KeyCode::Char('q') => app.quit(),
-                    KeyCode::Tab => {
-                        let next_view = match app.current_view {
-                            ViewState::ConnectionList => ViewState::DatabaseExplorer,
-                            ViewState::DatabaseExplorer => ViewState::QueryEditor,
-                            ViewState::QueryEditor => ViewState::ConnectionList,
-                        };
-                        app.switch_view(next_view);
+                // Check for Ctrl modifier first for pane switching
+                if key_event.modifiers.contains(KeyModifiers::CONTROL) {
+                    match key_event.code {
+                        KeyCode::Char('h') | KeyCode::Left => {
+                            app.move_focus_next_pane();
+                        }
+                        KeyCode::Char('j') | KeyCode::Down => {
+                            app.move_focus_next_pane();
+                        }
+                        KeyCode::Char('k') | KeyCode::Up => {
+                            app.move_focus_next_pane();
+                        }
+                        KeyCode::Char('l') | KeyCode::Right => {
+                            app.move_focus_next_pane();
+                        }
+                        _ => {}
                     }
-                    KeyCode::Esc => {
-                        app.switch_view(ViewState::ConnectionList);
+                } else {
+                    // Regular key handling
+                    match key_event.code {
+                        KeyCode::Char('q') => app.quit(),
+                        KeyCode::Tab => {
+                            let next_view = match app.current_view {
+                                ViewState::ConnectionList => ViewState::DatabaseExplorer,
+                                ViewState::DatabaseExplorer => ViewState::QueryEditor,
+                                ViewState::QueryEditor => ViewState::ConnectionList,
+                            };
+                            app.switch_view(next_view);
+                        }
+                        KeyCode::Esc => {
+                            app.switch_view(ViewState::ConnectionList);
+                        }
+                        // Vim-style navigation within panes
+                        KeyCode::Char('h') | KeyCode::Left => {
+                            app.move_within_pane(Direction::Left);
+                        }
+                        KeyCode::Char('j') | KeyCode::Down => {
+                            app.move_within_pane(Direction::Down);
+                        }
+                        KeyCode::Char('k') | KeyCode::Up => {
+                            app.move_within_pane(Direction::Up);
+                        }
+                        KeyCode::Char('l') | KeyCode::Right => {
+                            app.move_within_pane(Direction::Right);
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
         }

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -9,16 +9,16 @@ pub fn handle_events(app: &mut App) -> anyhow::Result<()> {
                 if key_event.modifiers.contains(KeyModifiers::CONTROL) {
                     match key_event.code {
                         KeyCode::Char('h') | KeyCode::Left => {
-                            app.move_focus_next_pane();
+                            app.move_focus_pane(Direction::Left);
                         }
                         KeyCode::Char('j') | KeyCode::Down => {
-                            app.move_focus_next_pane();
+                            app.move_focus_pane(Direction::Down);
                         }
                         KeyCode::Char('k') | KeyCode::Up => {
-                            app.move_focus_next_pane();
+                            app.move_focus_pane(Direction::Up);
                         }
                         KeyCode::Char('l') | KeyCode::Right => {
-                            app.move_focus_next_pane();
+                            app.move_focus_pane(Direction::Right);
                         }
                         _ => {}
                     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -103,7 +103,7 @@ fn render_main_content(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn render_footer(frame: &mut Frame, area: Rect, _app: &App) {
-    let footer_text = "q: Quit | Tab: Switch View | Enter: Select";
+    let footer_text = "q: Quit | Tab: Switch View | hjkl/←↓↑→: Navigate | Ctrl+hjkl/Ctrl+←↓↑→: Switch Pane | Esc: Home";
     let footer = ratatui::widgets::Paragraph::new(footer_text)
         .style(Style::default().fg(Color::Gray))
         .alignment(Alignment::Center)


### PR DESCRIPTION
## Summary
• Add comprehensive focus management system for all views with dedicated state structures
• Implement hjkl/arrow key navigation within panes for intuitive vim-style controls
• Add Ctrl+hjkl/Ctrl+arrow key navigation between panes for seamless pane switching
• Reset focus to first pane when switching views with Tab for consistent UX
• Add visual focus indicators with yellow borders to clearly show active pane
• Update footer with new navigation key bindings for better user guidance

## Technical Changes
- Extended App state with `ConnectionListState`, `DatabaseExplorerState`, and `QueryEditorState`
- Added pane-specific enums for each view type
- Implemented `move_focus_next_pane()` and `move_within_pane()` methods
- Enhanced event handling with modifier key detection
- Updated all UI components to render focus state with visual indicators

## Test Plan
- [x] Build and compile successfully
- [x] All existing tests pass
- [ ] Manual testing of navigation between views
- [ ] Manual testing of pane navigation within each view
- [ ] Manual testing of focus reset on view switching
- [ ] Verify visual focus indicators work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)