### PR TITLE
feat: add project creation UI with floating dialog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ dirs = "5.0"
 async-trait = "0.1"
 base64 = "0.22"
 ring = "0.17"
+uuid = { version = "1.10", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,5 +6,6 @@ pub use state::{
     ConnectionListPane, 
     DatabaseExplorerPane, 
     QueryEditorPane, 
-    Direction
+    Direction,
+    InputDialogType
 };

--- a/src/ui/components/connection_list.rs
+++ b/src/ui/components/connection_list.rs
@@ -21,7 +21,7 @@ fn render_projects_list(frame: &mut Frame, area: Rect, app: &App) {
         .projects
         .iter()
         .map(|project| {
-            ListItem::new(project.name.clone())
+            ListItem::new(format!("📁 {}", project.name))
         })
         .collect();
 

--- a/src/ui/components/input_dialog.rs
+++ b/src/ui/components/input_dialog.rs
@@ -1,0 +1,77 @@
+use crate::app::{App, InputDialogType};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+
+pub fn render(frame: &mut Frame, app: &App) {
+    if let Some(dialog_state) = &app.input_dialog_state {
+        let area = frame.area();
+        
+        // Create a centered popup area
+        let popup_area = centered_rect(50, 20, area);
+        
+        // Clear the background
+        let clear = Clear;
+        frame.render_widget(clear, popup_area);
+        
+        // Create the input block
+        let title = match dialog_state.input_type {
+            InputDialogType::NewProject => "New Project",
+        };
+        
+        let input_text = &dialog_state.input_text;
+        let cursor_pos = dialog_state.cursor_position;
+        
+        // Create input text with cursor
+        let mut input_with_cursor = input_text.clone();
+        if cursor_pos <= input_with_cursor.len() {
+            input_with_cursor.insert(cursor_pos, '|');
+        }
+        
+        let input_paragraph = Paragraph::new(input_with_cursor)
+            .style(Style::default().fg(Color::White))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(title)
+                    .border_style(Style::default().fg(Color::Yellow))
+            )
+            .wrap(Wrap { trim: false });
+        
+        frame.render_widget(input_paragraph, popup_area);
+        
+        // Render help text
+        let help_area = Rect {
+            x: popup_area.x,
+            y: popup_area.y + popup_area.height,
+            width: popup_area.width,
+            height: 1,
+        };
+        
+        let help_text = "Enter: Submit | Esc: Cancel";
+        let help_paragraph = Paragraph::new(help_text)
+            .style(Style::default().fg(Color::Gray))
+            .alignment(Alignment::Center);
+        
+        frame.render_widget(help_paragraph, help_area);
+    }
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -1,3 +1,4 @@
 pub mod connection_list;
 pub mod database_explorer;
 pub mod query_editor;
+pub mod input_dialog;

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1,12 +1,50 @@
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
-use crate::app::{App, ViewState, Direction};
+use crate::app::{App, ViewState, Direction, ConnectionListPane};
 
 pub fn handle_events(app: &mut App) -> anyhow::Result<()> {
     if event::poll(std::time::Duration::from_millis(50))? {
         if let Event::Key(key_event) = event::read()? {
             if key_event.kind == KeyEventKind::Press {
-                // Check for Ctrl modifier first for pane switching
-                if key_event.modifiers.contains(KeyModifiers::CONTROL) {
+                // Handle input dialog events first
+                if app.input_dialog_state.is_some() {
+                    match key_event.code {
+                        KeyCode::Enter => {
+                            app.submit_input_dialog()?;
+                        }
+                        KeyCode::Esc => {
+                            app.close_input_dialog();
+                        }
+                        KeyCode::Backspace => {
+                            app.handle_input_dialog_backspace();
+                        }
+                        KeyCode::Left => {
+                            app.handle_input_dialog_left();
+                        }
+                        KeyCode::Right => {
+                            app.handle_input_dialog_right();
+                        }
+                        KeyCode::Char(ch) => {
+                            app.handle_input_dialog_input(ch);
+                        }
+                        _ => {}
+                    }
+                    return Ok(());
+                }
+
+                // Check for Shift modifier for special actions
+                if key_event.modifiers.contains(KeyModifiers::SHIFT) {
+                    match key_event.code {
+                        KeyCode::Char('A') => {
+                            // Only show new project dialog if we're in ConnectionList view and Projects pane is focused
+                            if app.current_view == ViewState::ConnectionList 
+                                && app.connection_list_state.focused_pane == ConnectionListPane::Projects {
+                                app.show_new_project_dialog();
+                            }
+                        }
+                        _ => {}
+                    }
+                // Check for Ctrl modifier for pane switching
+                } else if key_event.modifiers.contains(KeyModifiers::CONTROL) {
                     match key_event.code {
                         KeyCode::Char('h') | KeyCode::Left => {
                             app.move_focus_next_pane();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,6 +18,11 @@ pub fn render(frame: &mut Frame, app: &App) {
     render_header(frame, chunks[0], app);
     render_main_content(frame, chunks[1], app);
     render_footer(frame, chunks[2], app);
+    
+    // Render input dialog on top if present
+    if app.input_dialog_state.is_some() {
+        components::input_dialog::render(frame, app);
+    }
 }
 
 fn render_header(frame: &mut Frame, area: Rect, app: &App) {
@@ -103,7 +108,7 @@ fn render_main_content(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn render_footer(frame: &mut Frame, area: Rect, _app: &App) {
-    let footer_text = "q: Quit | Tab: Switch View | hjkl/←↓↑→: Navigate | Ctrl+hjkl/Ctrl+←↓↑→: Switch Pane | Esc: Home";
+    let footer_text = "q: Quit | Tab: Switch View | hjkl/←↓↑→: Navigate | Ctrl+hjkl/Ctrl+←↓↑→: Switch Pane | Shift+A: Add Project | Esc: Home";
     let footer = ratatui::widgets::Paragraph::new(footer_text)
         .style(Style::default().fg(Color::Gray))
         .alignment(Alignment::Center)


### PR DESCRIPTION
## Summary
- Add Shift+A key binding to create new projects when Projects pane is focused
- Implement floating input dialog for project name entry with cursor support  
- Add folder emoji (📁) to project list display for better visual distinction
- Auto-save new projects to config file with unique UUID generation
- Update help text to show new Shift+A shortcut

## Features Added
- **Keyboard Shortcut**: Press Shift+A in Projects pane to open new project dialog
- **Floating Dialog**: Centered popup dialog for project name input
- **Text Input**: Full text editing with cursor navigation (left/right arrows, backspace)
- **Visual Enhancement**: Projects now display with 📁 emoji
- **Auto-save**: New projects are immediately saved to configuration file
- **User Feedback**: Updated footer help text to include new shortcut

## Technical Implementation
- Added `InputDialogState` and `InputDialogType` to app state management
- Created new `input_dialog` UI component with centered positioning
- Enhanced event handling for dialog-specific key bindings
- Integrated with existing project configuration system
- Added uuid dependency for unique project ID generation

## User Experience
1. Navigate to Connections tab
2. Focus Projects pane (left side)
3. Press **Shift+A** to open dialog
4. Type project name
5. Press **Enter** to create or **Esc** to cancel
6. New project appears immediately in list with 📁 icon

## Test Plan
- [x] Verify Shift+A only works when Projects pane is focused
- [x] Test text input with cursor navigation
- [x] Confirm project creation and persistence
- [x] Check emoji display in project list
- [x] Validate dialog cancellation with Esc key

🤖 Generated with [Claude Code](https://claude.ai/code)