### PR TITLE
feat: use $HOME/.config/lazydb for config.yaml on all OS

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -84,10 +84,10 @@ impl Config {
     }
 
     fn config_path() -> anyhow::Result<PathBuf> {
-        let config_dir = dirs::config_dir()
-            .ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?;
+        let home_dir = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
         
-        Ok(config_dir.join("lazydb").join("config.yaml"))
+        Ok(home_dir.join(".config").join("lazydb").join("config.yaml"))
     }
 
     pub fn add_connection(&mut self, connection: Connection) {


### PR DESCRIPTION
## Summary
- Change config file location from OS-specific directories to `$HOME/.config/lazydb/config.yaml` on all operating systems for consistency
- Modified `Config::config_path()` to use `dirs::home_dir()` instead of `dirs::config_dir()`

## Test plan
- [x] All existing config tests pass (7/7 tests successful)
- [x] Project builds successfully without errors  
- [x] Config file creation and loading works correctly

## Breaking Change
⚠️ This is a breaking change: Users will need to migrate existing config files from their OS-specific config directory to `$HOME/.config/lazydb/config.yaml`.

🤖 Generated with [Claude Code](https://claude.ai/code)