### PR TITLE
feat: ✨  add directional pane navigation with Shift + movement keys

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -483,6 +483,34 @@ impl App {
                 };
             }
 
+            Message::FocusLeft => {
+                // QueryEditor/MainPanel -> Sidebar
+                if self.focus == Focus::QueryEditor || self.focus == Focus::MainPanel {
+                    self.focus = Focus::Sidebar;
+                }
+            }
+
+            Message::FocusRight => {
+                // Sidebar -> QueryEditor
+                if self.focus == Focus::Sidebar {
+                    self.focus = Focus::QueryEditor;
+                }
+            }
+
+            Message::FocusUp => {
+                // MainPanel -> QueryEditor
+                if self.focus == Focus::MainPanel {
+                    self.focus = Focus::QueryEditor;
+                }
+            }
+
+            Message::FocusDown => {
+                // QueryEditor -> MainPanel
+                if self.focus == Focus::QueryEditor {
+                    self.focus = Focus::MainPanel;
+                }
+            }
+
             Message::Activate => {
                 if self.focus == Focus::Sidebar {
                     self.activate_current_item();

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,16 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
                     (KeyCode::Char('q'), _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                         Some(Message::Quit)
                     }
+                    // Shift + movement keys: directional pane navigation
+                    (KeyCode::Left, KeyModifiers::SHIFT)
+                    | (KeyCode::Char('H'), KeyModifiers::SHIFT) => Some(Message::FocusLeft),
+                    (KeyCode::Right, KeyModifiers::SHIFT)
+                    | (KeyCode::Char('L'), KeyModifiers::SHIFT) => Some(Message::FocusRight),
+                    (KeyCode::Up, KeyModifiers::SHIFT)
+                    | (KeyCode::Char('K'), KeyModifiers::SHIFT) => Some(Message::FocusUp),
+                    (KeyCode::Down, KeyModifiers::SHIFT)
+                    | (KeyCode::Char('J'), KeyModifiers::SHIFT) => Some(Message::FocusDown),
+                    // Regular navigation within current pane
                     (KeyCode::Up | KeyCode::Char('k'), _) => Some(Message::NavigateUp),
                     (KeyCode::Down | KeyCode::Char('j'), _) => Some(Message::NavigateDown),
                     (KeyCode::Tab, _) => Some(Message::NextFocus),

--- a/src/message.rs
+++ b/src/message.rs
@@ -5,6 +5,11 @@ pub enum Message {
     NavigateDown,
     NextFocus,
     PrevFocus,
+    // Directional pane focus (Shift + h/j/k/l or arrow keys)
+    FocusLeft,
+    FocusRight,
+    FocusUp,
+    FocusDown,
     Activate,
     ToggleExpandCollapse,
     SwitchToSchema,

--- a/src/ui/help_bar.rs
+++ b/src/ui/help_bar.rs
@@ -12,6 +12,7 @@ pub fn draw_help_bar(frame: &mut Frame, area: Rect) {
         ("↑/k", "Up"),
         ("↓/j", "Down"),
         ("Tab", "Focus"),
+        ("S-hjkl", "Pane"),
         ("Enter", "Select"),
         ("e", "Expand"),
         ("s", "Schema"),


### PR DESCRIPTION
## Summary

- Shift + h/j/k/l または Shift + 矢印キーで pane 間を方向性を持って移動できる機能を追加
- 既存の Tab キーによる循環的なフォーカス移動に加え、空間的なナビゲーションが可能に
- ヘルプバーに新しいキーバインド (`S-hjkl Pane`) を追加

## Key bindings

| Key | Action |
|-----|--------|
| `Shift+h` / `Shift+←` | Move to left pane (Sidebar) |
| `Shift+l` / `Shift+→` | Move to right pane (QueryEditor) |
| `Shift+k` / `Shift+↑` | Move to upper pane (QueryEditor) |
| `Shift+j` / `Shift+↓` | Move to lower pane (MainPanel) |

## Test plan

- [ ] `Shift+h` で右側の pane から Sidebar に移動できることを確認
- [ ] `Shift+l` で Sidebar から QueryEditor に移動できることを確認
- [ ] `Shift+k` で MainPanel から QueryEditor に移動できることを確認
- [ ] `Shift+j` で QueryEditor から MainPanel に移動できることを確認
- [ ] 矢印キーでも同様の動作を確認
- [ ] 既存の Tab/Shift+Tab による循環移動が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)