### PR TITLE
feat: ⚡ implement connection pooling for PostgresProvider (#32)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,8 @@ dependencies = [
  "encoding_rs",
  "itertools",
  "postgres",
+ "r2d2",
+ "r2d2_postgres",
  "ratatui",
  "serde",
  "serde_json",
@@ -883,6 +885,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_postgres"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd4b47636dbca581cd057e2f27a5d39be741ea4f85fd3c29e415c55f71c7595"
+dependencies = [
+ "postgres",
+ "r2d2",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1012,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ shellexpand = "3.1"
 chrono = { version = "0.4", features = ["serde"] }
 unicode-width = "0.2"
 postgres = "0.19"
+r2d2 = "0.8"
+r2d2_postgres = "0.18"
 encoding_rs = "0.8"
 
 [dev-dependencies]

--- a/src/db/postgres/mod.rs
+++ b/src/db/postgres/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides a PostgreSQL implementation of the DatabaseProvider trait.
 
 mod helpers;
+mod pool;
 mod provider;
 mod queries;
 mod trait_impl;
@@ -13,5 +14,6 @@ mod tests;
 // Re-export from parent for internal use
 pub(super) use super::provider::{DatabaseProvider, DatabaseType, ProviderError};
 
-// Re-export the main type
+// Re-export the main types
+pub use pool::{ConnectionPool, PoolConfig, PoolState};
 pub use provider::PostgresProvider;

--- a/src/db/postgres/pool.rs
+++ b/src/db/postgres/pool.rs
@@ -1,0 +1,374 @@
+//! Connection pool for PostgreSQL
+//!
+//! Provides connection pooling using r2d2 for improved performance
+//! by reusing database connections instead of creating new ones for each operation.
+
+use r2d2::{Pool, PooledConnection};
+use r2d2_postgres::{postgres::NoTls, PostgresConnectionManager};
+use std::time::Duration;
+
+use super::ProviderError;
+
+/// Default maximum number of connections in the pool
+pub const DEFAULT_MAX_SIZE: u32 = 10;
+/// Default minimum number of idle connections to maintain
+pub const DEFAULT_MIN_IDLE: u32 = 1;
+/// Default connection timeout in seconds
+pub const DEFAULT_CONNECTION_TIMEOUT_SECS: u64 = 30;
+/// Default maximum lifetime of a connection in seconds (30 minutes)
+pub const DEFAULT_MAX_LIFETIME_SECS: u64 = 30 * 60;
+/// Default idle timeout in seconds (10 minutes)
+pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 10 * 60;
+
+/// Configuration for the connection pool
+#[derive(Debug, Clone)]
+pub struct PoolConfig {
+    /// Maximum number of connections in the pool
+    pub max_size: u32,
+    /// Minimum number of idle connections to maintain
+    pub min_idle: Option<u32>,
+    /// Maximum time to wait for a connection from the pool
+    pub connection_timeout: Duration,
+    /// Maximum lifetime of a connection
+    pub max_lifetime: Option<Duration>,
+    /// Time after which idle connections are closed
+    pub idle_timeout: Option<Duration>,
+}
+
+impl Default for PoolConfig {
+    fn default() -> Self {
+        Self {
+            max_size: DEFAULT_MAX_SIZE,
+            min_idle: Some(DEFAULT_MIN_IDLE),
+            connection_timeout: Duration::from_secs(DEFAULT_CONNECTION_TIMEOUT_SECS),
+            max_lifetime: Some(Duration::from_secs(DEFAULT_MAX_LIFETIME_SECS)),
+            idle_timeout: Some(Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS)),
+        }
+    }
+}
+
+impl PoolConfig {
+    /// Validate the configuration values
+    ///
+    /// Returns an error if:
+    /// - `max_size` is 0
+    /// - `min_idle` is greater than `max_size`
+    pub fn validate(&self) -> Result<(), ProviderError> {
+        if self.max_size == 0 {
+            return Err(ProviderError::InvalidConfiguration(
+                "max_size must be greater than 0".to_string(),
+            ));
+        }
+        if let Some(min_idle) = self.min_idle {
+            if min_idle > self.max_size {
+                return Err(ProviderError::InvalidConfiguration(format!(
+                    "min_idle ({}) cannot be greater than max_size ({})",
+                    min_idle, self.max_size
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A connection pool for PostgreSQL connections.
+///
+/// # Thread Safety
+///
+/// `ConnectionPool` is both `Send` and `Sync`, making it safe to share across threads.
+/// The underlying r2d2 pool handles connection management and synchronization internally.
+/// Multiple threads can safely call `get()` concurrently to obtain connections.
+#[derive(Clone)]
+pub struct ConnectionPool {
+    pool: Pool<PostgresConnectionManager<NoTls>>,
+}
+
+impl ConnectionPool {
+    /// Create a new connection pool with the given configuration
+    pub fn new(
+        host: &str,
+        port: u16,
+        database: &str,
+        username: &str,
+        password: &str,
+        config: PoolConfig,
+    ) -> Result<Self, ProviderError> {
+        // Validate configuration before creating pool
+        config.validate()?;
+
+        let mut pg_config = postgres::Config::new();
+        pg_config
+            .host(host)
+            .port(port)
+            .dbname(database)
+            .user(username)
+            .password(password);
+
+        let manager = PostgresConnectionManager::new(pg_config, NoTls);
+
+        let pool = Pool::builder()
+            .max_size(config.max_size)
+            .min_idle(config.min_idle)
+            .connection_timeout(config.connection_timeout)
+            .max_lifetime(config.max_lifetime)
+            .idle_timeout(config.idle_timeout)
+            .build(manager)
+            .map_err(|e| ProviderError::ConnectionFailed(e.to_string()))?;
+
+        Ok(Self { pool })
+    }
+
+    /// Create a new connection pool with default configuration
+    pub fn with_defaults(
+        host: &str,
+        port: u16,
+        database: &str,
+        username: &str,
+        password: &str,
+    ) -> Result<Self, ProviderError> {
+        Self::new(
+            host,
+            port,
+            database,
+            username,
+            password,
+            PoolConfig::default(),
+        )
+    }
+
+    /// Get a connection from the pool
+    pub fn get(&self) -> Result<PooledConnection<PostgresConnectionManager<NoTls>>, ProviderError> {
+        self.pool.get().map_err(|e| {
+            let state = self.pool.state();
+            ProviderError::ConnectionFailed(format!(
+                "Failed to get connection from pool: {} (pool state: {} connections, {} idle, max {})",
+                e, state.connections, state.idle_connections, self.pool.max_size()
+            ))
+        })
+    }
+
+    /// Get the current state of the pool
+    pub fn state(&self) -> PoolState {
+        let state = self.pool.state();
+        PoolState {
+            connections: state.connections,
+            idle_connections: state.idle_connections,
+        }
+    }
+
+    /// Get the maximum pool size
+    pub fn max_size(&self) -> u32 {
+        self.pool.max_size()
+    }
+}
+
+/// State of the connection pool
+#[derive(Debug, Clone, Copy)]
+pub struct PoolState {
+    /// Total number of connections in the pool
+    pub connections: u32,
+    /// Number of idle connections
+    pub idle_connections: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pool_config_default() {
+        let config = PoolConfig::default();
+        assert_eq!(config.max_size, DEFAULT_MAX_SIZE);
+        assert_eq!(config.min_idle, Some(DEFAULT_MIN_IDLE));
+        assert_eq!(
+            config.connection_timeout,
+            Duration::from_secs(DEFAULT_CONNECTION_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn test_pool_config_validation_success() {
+        let config = PoolConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_pool_config_validation_max_size_zero() {
+        let config = PoolConfig {
+            max_size: 0,
+            ..Default::default()
+        };
+        match config.validate() {
+            Err(ProviderError::InvalidConfiguration(msg)) => {
+                assert!(msg.contains("max_size"));
+            }
+            other => panic!("Expected InvalidConfiguration, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_pool_config_validation_min_idle_greater_than_max() {
+        let config = PoolConfig {
+            max_size: 5,
+            min_idle: Some(10),
+            ..Default::default()
+        };
+        match config.validate() {
+            Err(ProviderError::InvalidConfiguration(msg)) => {
+                assert!(msg.contains("min_idle"));
+                assert!(msg.contains("max_size"));
+            }
+            other => panic!("Expected InvalidConfiguration, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_pool_creation_failure_invalid_host() {
+        let result = ConnectionPool::with_defaults(
+            "nonexistent.invalid.host.example.com",
+            5432,
+            "testdb",
+            "user",
+            "pass",
+        );
+
+        assert!(result.is_err());
+        match result {
+            Err(ProviderError::ConnectionFailed(msg)) => {
+                println!("Expected connection failure: {}", msg);
+            }
+            Err(other) => panic!("Expected ConnectionFailed, got: {:?}", other),
+            Ok(_) => panic!("Expected connection to fail"),
+        }
+    }
+
+    #[test]
+    fn test_pool_creation_failure_invalid_port() {
+        let result = ConnectionPool::with_defaults("localhost", 1, "testdb", "user", "pass");
+
+        assert!(result.is_err());
+        match result {
+            Err(ProviderError::ConnectionFailed(msg)) => {
+                println!("Expected connection failure: {}", msg);
+            }
+            Err(other) => panic!("Expected ConnectionFailed, got: {:?}", other),
+            Ok(_) => panic!("Expected connection to fail"),
+        }
+    }
+
+    #[test]
+    #[ignore] // Requires database connection
+    fn test_pool_creation_success() {
+        let pool =
+            ConnectionPool::with_defaults("localhost", 5432, "lazydb_dev", "lazydb", "lazydb")
+                .expect("Failed to create pool");
+
+        let state = pool.state();
+        assert!(
+            state.connections >= 1,
+            "Pool should have at least one connection"
+        );
+        assert_eq!(pool.max_size(), 10);
+    }
+
+    #[test]
+    #[ignore] // Requires database connection
+    fn test_pool_get_connection() {
+        let pool =
+            ConnectionPool::with_defaults("localhost", 5432, "lazydb_dev", "lazydb", "lazydb")
+                .expect("Failed to create pool");
+
+        // Get a connection and use it
+        let mut conn = pool.get().expect("Failed to get connection");
+        let result = conn
+            .query_one("SELECT 1 as value", &[])
+            .expect("Query failed");
+        let value: i32 = result.get("value");
+        assert_eq!(value, 1);
+    }
+
+    #[test]
+    #[ignore] // Requires database connection
+    fn test_pool_connection_reuse() {
+        let pool =
+            ConnectionPool::with_defaults("localhost", 5432, "lazydb_dev", "lazydb", "lazydb")
+                .expect("Failed to create pool");
+
+        // Get and release multiple connections
+        for i in 0..5 {
+            let mut conn = pool.get().expect("Failed to get connection");
+            let result = conn
+                .query_one("SELECT $1::int as value", &[&i])
+                .expect("Query failed");
+            let value: i32 = result.get("value");
+            assert_eq!(value, i);
+            // Connection is automatically returned to pool when dropped
+        }
+
+        let state = pool.state();
+        // After releasing all connections, we should have idle connections
+        assert!(
+            state.idle_connections >= 1,
+            "Pool should have idle connections after use"
+        );
+    }
+
+    #[test]
+    #[ignore] // Requires database connection
+    fn test_pool_concurrent_connections() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let pool = Arc::new(
+            ConnectionPool::new(
+                "localhost",
+                5432,
+                "lazydb_dev",
+                "lazydb",
+                "lazydb",
+                PoolConfig {
+                    max_size: 5,
+                    min_idle: Some(2),
+                    ..Default::default()
+                },
+            )
+            .expect("Failed to create pool"),
+        );
+
+        // Spawn multiple threads that use connections concurrently
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let pool_clone = Arc::clone(&pool);
+                thread::spawn(move || {
+                    let mut conn = pool_clone.get().expect("Failed to get connection");
+                    let result = conn
+                        .query_one("SELECT $1::int as value", &[&i])
+                        .expect("Query failed");
+                    let value: i32 = result.get("value");
+                    assert_eq!(value, i);
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("Thread panicked");
+        }
+    }
+
+    #[test]
+    #[ignore] // Requires database connection
+    fn test_pool_custom_config() {
+        let config = PoolConfig {
+            max_size: 5,
+            min_idle: Some(2),
+            connection_timeout: Duration::from_secs(10),
+            max_lifetime: Some(Duration::from_secs(60)),
+            idle_timeout: Some(Duration::from_secs(30)),
+        };
+
+        let pool = ConnectionPool::new("localhost", 5432, "lazydb_dev", "lazydb", "lazydb", config)
+            .expect("Failed to create pool");
+
+        assert_eq!(pool.max_size(), 5);
+    }
+}

--- a/src/db/postgres/provider.rs
+++ b/src/db/postgres/provider.rs
@@ -1,15 +1,53 @@
 //! PostgresProvider struct and connection methods
 
 use postgres::{Client, NoTls};
+use r2d2::PooledConnection;
+use r2d2_postgres::PostgresConnectionManager;
 use std::sync::Mutex;
 
 use crate::config::ConnectionConfig;
 
+use super::pool::{ConnectionPool, PoolState};
 use super::ProviderError;
+
+/// Connection source for PostgresProvider
+enum ConnectionSource {
+    /// Single connection wrapped in a Mutex (boxed to reduce enum size)
+    Single(Box<Mutex<Client>>),
+    /// Connection pool
+    Pool(ConnectionPool),
+}
 
 /// PostgreSQL database provider
 pub struct PostgresProvider {
-    pub(super) client: Mutex<Client>,
+    source: ConnectionSource,
+}
+
+/// A wrapper that provides a uniform interface for both single and pooled connections
+pub(super) enum ConnectionGuard<'a> {
+    Single(std::sync::MutexGuard<'a, Client>),
+    /// Boxed to reduce enum size difference
+    Pooled(Box<PooledConnection<PostgresConnectionManager<NoTls>>>),
+}
+
+impl<'a> std::ops::Deref for ConnectionGuard<'a> {
+    type Target = Client;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            ConnectionGuard::Single(guard) => guard,
+            ConnectionGuard::Pooled(conn) => conn,
+        }
+    }
+}
+
+impl<'a> std::ops::DerefMut for ConnectionGuard<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            ConnectionGuard::Single(guard) => &mut *guard,
+            ConnectionGuard::Pooled(conn) => conn,
+        }
+    }
 }
 
 impl PostgresProvider {
@@ -27,7 +65,7 @@ impl PostgresProvider {
             .map_err(|e| ProviderError::ConnectionFailed(e.to_string()))?;
 
         Ok(Self {
-            client: Mutex::new(client),
+            source: ConnectionSource::Single(Box::new(Mutex::new(client))),
         })
     }
 
@@ -55,7 +93,67 @@ impl PostgresProvider {
             .map_err(|e| ProviderError::ConnectionFailed(e.to_string()))?;
 
         Ok(Self {
-            client: Mutex::new(client),
+            source: ConnectionSource::Single(Box::new(Mutex::new(client))),
         })
+    }
+
+    /// Create a new PostgresProvider using a connection pool.
+    ///
+    /// This is the preferred method for applications that need to handle
+    /// multiple concurrent database operations efficiently.
+    pub fn with_pool(pool: ConnectionPool) -> Self {
+        Self {
+            source: ConnectionSource::Pool(pool),
+        }
+    }
+
+    /// Create a new PostgresProvider with a connection pool using default pool settings.
+    ///
+    /// This is a convenience method that combines connection and pool creation
+    /// in a single call. For custom pool configuration, use [`ConnectionPool::new`]
+    /// followed by [`PostgresProvider::with_pool`].
+    pub fn connect_with_pool(
+        host: &str,
+        port: u16,
+        database: &str,
+        username: &str,
+        password: &str,
+    ) -> Result<Self, ProviderError> {
+        let pool = ConnectionPool::with_defaults(host, port, database, username, password)?;
+        Ok(Self::with_pool(pool))
+    }
+
+    /// Get a connection from the provider.
+    ///
+    /// For single-connection mode, this acquires the mutex lock.
+    /// For pooled mode, this gets a connection from the pool.
+    pub(super) fn get_connection(&self) -> Result<ConnectionGuard<'_>, ProviderError> {
+        match &self.source {
+            ConnectionSource::Single(mutex) => {
+                let guard = mutex.lock().map_err(|e| {
+                    ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
+                })?;
+                Ok(ConnectionGuard::Single(guard))
+            }
+            ConnectionSource::Pool(pool) => {
+                let conn = pool.get()?;
+                Ok(ConnectionGuard::Pooled(Box::new(conn)))
+            }
+        }
+    }
+
+    /// Get the pool state if using a connection pool.
+    ///
+    /// Returns `None` if using a single connection.
+    pub fn pool_state(&self) -> Option<PoolState> {
+        match &self.source {
+            ConnectionSource::Single(_) => None,
+            ConnectionSource::Pool(pool) => Some(pool.state()),
+        }
+    }
+
+    /// Check if this provider is using a connection pool.
+    pub fn is_pooled(&self) -> bool {
+        matches!(&self.source, ConnectionSource::Pool(_))
     }
 }

--- a/src/db/postgres/trait_impl.rs
+++ b/src/db/postgres/trait_impl.rs
@@ -22,9 +22,7 @@ impl DatabaseProvider for PostgresProvider {
             ORDER BY schema_name
         "#;
 
-        let mut client = self.client.lock().map_err(|e| {
-            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
-        })?;
+        let mut client = self.get_connection()?;
 
         let rows = client
             .query(query, &[])
@@ -52,9 +50,7 @@ impl DatabaseProvider for PostgresProvider {
             ORDER BY t.table_name
         "#;
 
-        let mut client = self.client.lock().map_err(|e| {
-            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
-        })?;
+        let mut client = self.get_connection()?;
 
         let rows = client
             .query(query, &[&schema])
@@ -102,9 +98,7 @@ impl DatabaseProvider for PostgresProvider {
             WHERE t.table_schema = $1 AND t.table_name = $2
         "#;
 
-        let mut client = self.client.lock().map_err(|e| {
-            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
-        })?;
+        let mut client = self.get_connection()?;
 
         let table_rows = client
             .query(table_query, &[&schema_str, &table_name])
@@ -162,9 +156,7 @@ impl DatabaseProvider for PostgresProvider {
     fn execute_query(&self, query: &str) -> Result<QueryResult, ProviderError> {
         let start = Instant::now();
 
-        let mut client = self.client.lock().map_err(|e| {
-            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
-        })?;
+        let mut client = self.get_connection()?;
 
         let rows = client
             .query(query, &[])
@@ -232,9 +224,7 @@ impl DatabaseProvider for PostgresProvider {
             quote_identifier(table_name)
         );
 
-        let mut client = self.client.lock().map_err(|e| {
-            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
-        })?;
+        let mut client = self.get_connection()?;
 
         let rows = client
             .query(&query, &[])
@@ -254,9 +244,7 @@ impl DatabaseProvider for PostgresProvider {
             )
         "#;
 
-        let mut client = self.client.lock().map_err(|e| {
-            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
-        })?;
+        let mut client = self.get_connection()?;
 
         let rows = client
             .query(query, &[&schema, &table_name])
@@ -273,9 +261,7 @@ impl DatabaseProvider for PostgresProvider {
     }
 
     fn test_connection(&self) -> Result<(), ProviderError> {
-        let mut client = self.client.lock().map_err(|e| {
-            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
-        })?;
+        let mut client = self.get_connection()?;
 
         client
             .query("SELECT 1", &[])
@@ -284,9 +270,7 @@ impl DatabaseProvider for PostgresProvider {
     }
 
     fn get_version(&self) -> Result<String, ProviderError> {
-        let mut client = self.client.lock().map_err(|e| {
-            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
-        })?;
+        let mut client = self.get_connection()?;
 
         let rows = client
             .query("SELECT version()", &[])


### PR DESCRIPTION
## Summary

PostgresProvider に接続プーリング機能を追加しました。

- r2d2 + r2d2_postgres を使用した接続プール実装
- 単一接続モードとプールモードの両方をサポート
- 既存APIとの後方互換性を維持

### 主な変更点

- `ConnectionPool` - r2d2ベースの接続プール管理
- `PoolConfig` - プール設定（max_size, min_idle, タイムアウト等）
- `PostgresProvider::with_pool()` - プールを使用したプロバイダ作成
- `pool_state()` - プール状態の取得
- `ConnectionGuard` - 統一的な接続インターフェース

### 使用例

```rust
// プールを使用する場合（推奨）
let pool = ConnectionPool::with_defaults("localhost", 5432, "db", "user", "pass")?;
let provider = PostgresProvider::with_pool(pool);

// カスタム設定
let config = PoolConfig {
    max_size: 5,
    min_idle: Some(2),
    ..Default::default()
};
let pool = ConnectionPool::new("localhost", 5432, "db", "user", "pass", config)?;
```

## Test plan

- [x] 単体テスト追加・パス (167 tests)
- [x] Clippy警告なし
- [x] フォーマット確認済み
- [ ] データベース接続を使用した統合テスト (`cargo test -- --ignored`)

Closes #32