### PR TITLE
feat: 🚸 improve error messages for better UX

### DIFF
--- a/src/db/provider.rs
+++ b/src/db/provider.rs
@@ -187,8 +187,9 @@ fn format_connection_error(msg: &str) -> String {
             msg
         )
     } else if msg_lower.contains("authentication failed")
-        || msg_lower.contains("password")
-        || msg_lower.contains("auth")
+        || msg_lower.contains("invalid password")
+        || ((msg_lower.contains("password") || msg_lower.contains("auth"))
+            && (msg_lower.contains("fail") || msg_lower.contains("denied")))
     {
         format!(
             "Authentication failed: Invalid username or password. \
@@ -270,7 +271,9 @@ fn format_query_error(msg: &str) -> String {
              (Details: {})",
             msg
         )
-    } else if msg_lower.contains("foreign key") || msg_lower.contains("violates") {
+    } else if msg_lower.contains("foreign key")
+        || (msg_lower.contains("violates") && msg_lower.contains("constraint"))
+    {
         format!(
             "Foreign key constraint violation: The operation conflicts with a foreign key. \
              (Details: {})",
@@ -283,7 +286,10 @@ fn format_query_error(msg: &str) -> String {
              (Details: {})",
             msg
         )
-    } else if msg_lower.contains("out of memory") || msg_lower.contains("memory") {
+    } else if msg_lower.contains("out of memory")
+        || msg_lower.contains("memory limit")
+        || msg_lower.contains("insufficient memory")
+    {
         format!(
             "Memory error: The query requires more memory than available. \
              Try simplifying the query or contact your administrator. \

--- a/src/db/provider.rs
+++ b/src/db/provider.rs
@@ -313,16 +313,13 @@ mod tests {
 
         // ユーザーフレンドリーなメッセージを含むべき
         assert!(
-            display.contains("接続が拒否されました") || display.contains("Connection refused"),
+            display.contains("Connection refused"),
             "Expected user-friendly connection refused message, got: {}",
             display
         );
         // 対処法のヒントを含むべき
         assert!(
-            display.contains("ホスト")
-                || display.contains("ポート")
-                || display.contains("host")
-                || display.contains("port"),
+            display.contains("host") || display.contains("port"),
             "Expected hint about host/port, got: {}",
             display
         );
@@ -338,10 +335,7 @@ mod tests {
 
         // 認証エラーとわかるメッセージを含むべき
         assert!(
-            display.contains("認証")
-                || display.contains("パスワード")
-                || display.contains("authentication")
-                || display.contains("password"),
+            display.contains("Authentication") || display.contains("password"),
             "Expected authentication error message, got: {}",
             display
         );
@@ -357,10 +351,7 @@ mod tests {
 
         // ホスト名エラーとわかるメッセージを含むべき
         assert!(
-            display.contains("ホスト名")
-                || display.contains("解決")
-                || display.contains("host")
-                || display.contains("resolve"),
+            display.contains("Host not found") || display.contains("resolve"),
             "Expected hostname resolution error message, got: {}",
             display
         );
@@ -374,9 +365,7 @@ mod tests {
 
         // タイムアウトエラーとわかるメッセージを含むべき
         assert!(
-            display.contains("タイムアウト")
-                || display.contains("timeout")
-                || display.contains("Timeout"),
+            display.contains("timeout") || display.contains("Timeout"),
             "Expected timeout error message, got: {}",
             display
         );
@@ -394,7 +383,7 @@ mod tests {
 
         // 構文エラーとわかるメッセージを含むべき
         assert!(
-            display.contains("構文") || display.contains("syntax") || display.contains("Syntax"),
+            display.contains("SQL syntax error") || display.contains("syntax"),
             "Expected syntax error message, got: {}",
             display
         );
@@ -409,11 +398,7 @@ mod tests {
 
         // テーブルが見つからないとわかるメッセージを含むべき
         assert!(
-            display.contains("テーブル")
-                || display.contains("存在しません")
-                || display.contains("table")
-                || display.contains("not exist")
-                || display.contains("not found"),
+            display.contains("Table not found") || display.contains("does not exist"),
             "Expected table not found message, got: {}",
             display
         );
@@ -428,7 +413,7 @@ mod tests {
 
         // カラムが見つからないとわかるメッセージを含むべき
         assert!(
-            display.contains("カラム") || display.contains("列") || display.contains("column"),
+            display.contains("Column not found") || display.contains("column"),
             "Expected column not found message, got: {}",
             display
         );
@@ -442,9 +427,7 @@ mod tests {
 
         // 権限エラーとわかるメッセージを含むべき
         assert!(
-            display.contains("権限")
-                || display.contains("permission")
-                || display.contains("Permission"),
+            display.contains("Permission denied") || display.contains("permission"),
             "Expected permission error message, got: {}",
             display
         );
@@ -460,9 +443,7 @@ mod tests {
         let display = error.to_string();
 
         assert!(
-            display.contains("タイムアウト")
-                || display.contains("timeout")
-                || display.contains("Timeout"),
+            display.contains("Timeout"),
             "Expected timeout message, got: {}",
             display
         );
@@ -474,11 +455,7 @@ mod tests {
         let display = error.to_string();
 
         assert!(
-            display.contains("権限")
-                || display.contains("アクセス")
-                || display.contains("permission")
-                || display.contains("Permission")
-                || display.contains("access"),
+            display.contains("Permission denied"),
             "Expected permission denied message, got: {}",
             display
         );
@@ -490,9 +467,7 @@ mod tests {
         let display = error.to_string();
 
         assert!(
-            display.contains("見つかりません")
-                || display.contains("not found")
-                || display.contains("Not found"),
+            display.contains("Not found"),
             "Expected not found message, got: {}",
             display
         );
@@ -504,10 +479,7 @@ mod tests {
         let display = error.to_string();
 
         assert!(
-            display.contains("設定")
-                || display.contains("configuration")
-                || display.contains("Configuration")
-                || display.contains("config"),
+            display.contains("Invalid configuration"),
             "Expected configuration error message, got: {}",
             display
         );
@@ -520,9 +492,7 @@ mod tests {
 
         // 内部エラーでもユーザーに理解できるメッセージを含むべき
         assert!(
-            display.contains("内部")
-                || display.contains("internal")
-                || display.contains("Internal"),
+            display.contains("Internal error"),
             "Expected internal error message, got: {}",
             display
         );

--- a/src/db/provider.rs
+++ b/src/db/provider.rs
@@ -170,3 +170,235 @@ impl std::fmt::Display for ProviderError {
 }
 
 impl std::error::Error for ProviderError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===========================================
+    // 接続エラーのテスト
+    // ===========================================
+
+    #[test]
+    fn test_connection_failed_displays_user_friendly_message() {
+        // 接続拒否エラー
+        let error = ProviderError::ConnectionFailed("connection refused".to_string());
+        let display = error.to_string();
+
+        // ユーザーフレンドリーなメッセージを含むべき
+        assert!(
+            display.contains("接続が拒否されました")
+                || display.contains("Connection refused"),
+            "Expected user-friendly connection refused message, got: {}",
+            display
+        );
+        // 対処法のヒントを含むべき
+        assert!(
+            display.contains("ホスト") || display.contains("ポート") || display.contains("host") || display.contains("port"),
+            "Expected hint about host/port, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_connection_failed_displays_auth_error_message() {
+        // 認証エラー
+        let error = ProviderError::ConnectionFailed(
+            "password authentication failed for user \"postgres\"".to_string(),
+        );
+        let display = error.to_string();
+
+        // 認証エラーとわかるメッセージを含むべき
+        assert!(
+            display.contains("認証") || display.contains("パスワード")
+                || display.contains("authentication") || display.contains("password"),
+            "Expected authentication error message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_connection_failed_displays_hostname_error_message() {
+        // ホスト名解決エラー
+        let error = ProviderError::ConnectionFailed(
+            "could not translate host name \"invalid-host\" to address".to_string(),
+        );
+        let display = error.to_string();
+
+        // ホスト名エラーとわかるメッセージを含むべき
+        assert!(
+            display.contains("ホスト名") || display.contains("解決")
+                || display.contains("host") || display.contains("resolve"),
+            "Expected hostname resolution error message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_connection_failed_displays_timeout_message() {
+        // タイムアウトエラー
+        let error = ProviderError::ConnectionFailed("connection timed out".to_string());
+        let display = error.to_string();
+
+        // タイムアウトエラーとわかるメッセージを含むべき
+        assert!(
+            display.contains("タイムアウト") || display.contains("timeout") || display.contains("Timeout"),
+            "Expected timeout error message, got: {}",
+            display
+        );
+    }
+
+    // ===========================================
+    // クエリエラーのテスト
+    // ===========================================
+
+    #[test]
+    fn test_query_failed_displays_syntax_error_message() {
+        // SQL構文エラー
+        let error = ProviderError::QueryFailed(
+            "syntax error at or near \"SELEC\"".to_string(),
+        );
+        let display = error.to_string();
+
+        // 構文エラーとわかるメッセージを含むべき
+        assert!(
+            display.contains("構文") || display.contains("syntax") || display.contains("Syntax"),
+            "Expected syntax error message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_query_failed_displays_table_not_found_message() {
+        // テーブルが見つからないエラー
+        let error = ProviderError::QueryFailed(
+            "relation \"nonexistent_table\" does not exist".to_string(),
+        );
+        let display = error.to_string();
+
+        // テーブルが見つからないとわかるメッセージを含むべき
+        assert!(
+            display.contains("テーブル") || display.contains("存在しません")
+                || display.contains("table") || display.contains("not exist") || display.contains("not found"),
+            "Expected table not found message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_query_failed_displays_column_not_found_message() {
+        // カラムが見つからないエラー
+        let error = ProviderError::QueryFailed(
+            "column \"nonexistent_column\" does not exist".to_string(),
+        );
+        let display = error.to_string();
+
+        // カラムが見つからないとわかるメッセージを含むべき
+        assert!(
+            display.contains("カラム") || display.contains("列")
+                || display.contains("column"),
+            "Expected column not found message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_query_failed_displays_permission_error_message() {
+        // 権限エラー
+        let error = ProviderError::QueryFailed(
+            "permission denied for table users".to_string(),
+        );
+        let display = error.to_string();
+
+        // 権限エラーとわかるメッセージを含むべき
+        assert!(
+            display.contains("権限") || display.contains("permission") || display.contains("Permission"),
+            "Expected permission error message, got: {}",
+            display
+        );
+    }
+
+    // ===========================================
+    // その他のエラーのテスト
+    // ===========================================
+
+    #[test]
+    fn test_timeout_error_displays_user_friendly_message() {
+        let error = ProviderError::Timeout("query took too long".to_string());
+        let display = error.to_string();
+
+        assert!(
+            display.contains("タイムアウト") || display.contains("timeout") || display.contains("Timeout"),
+            "Expected timeout message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_permission_denied_displays_user_friendly_message() {
+        let error = ProviderError::PermissionDenied("access denied to schema".to_string());
+        let display = error.to_string();
+
+        assert!(
+            display.contains("権限") || display.contains("アクセス")
+                || display.contains("permission") || display.contains("Permission") || display.contains("access"),
+            "Expected permission denied message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_not_found_displays_user_friendly_message() {
+        let error = ProviderError::NotFound("resource not available".to_string());
+        let display = error.to_string();
+
+        assert!(
+            display.contains("見つかりません") || display.contains("not found") || display.contains("Not found"),
+            "Expected not found message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_invalid_configuration_displays_user_friendly_message() {
+        let error = ProviderError::InvalidConfiguration("invalid port number".to_string());
+        let display = error.to_string();
+
+        assert!(
+            display.contains("設定") || display.contains("configuration") || display.contains("Configuration") || display.contains("config"),
+            "Expected configuration error message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_internal_error_displays_user_friendly_message() {
+        let error = ProviderError::InternalError("mutex poisoned".to_string());
+        let display = error.to_string();
+
+        // 内部エラーでもユーザーに理解できるメッセージを含むべき
+        assert!(
+            display.contains("内部") || display.contains("internal") || display.contains("Internal"),
+            "Expected internal error message, got: {}",
+            display
+        );
+    }
+
+    // ===========================================
+    // エラーメッセージにデバッグ情報を含むテスト
+    // ===========================================
+
+    #[test]
+    fn test_error_preserves_original_details() {
+        let original_error = "connection refused (os error 111)";
+        let error = ProviderError::ConnectionFailed(original_error.to_string());
+        let display = error.to_string();
+
+        // デバッグのため、元のエラー情報も含むべき
+        assert!(
+            display.contains("111") || display.contains("refused"),
+            "Expected original error details to be preserved, got: {}",
+            display
+        );
+    }
+}

--- a/src/export/error.rs
+++ b/src/export/error.rs
@@ -134,7 +134,7 @@ mod tests {
         let display = err.to_string();
 
         assert!(
-            display.contains("Directory not found") || display.contains("ディレクトリ"),
+            display.contains("Directory not found"),
             "Expected directory not found message, got: {}",
             display
         );
@@ -144,7 +144,7 @@ mod tests {
             display
         );
         assert!(
-            display.contains("Create") || display.contains("作成"),
+            display.contains("Create"),
             "Expected hint to create directory, got: {}",
             display
         );
@@ -158,7 +158,7 @@ mod tests {
         let display = err.to_string();
 
         assert!(
-            display.contains("Permission denied") || display.contains("権限"),
+            display.contains("Permission denied"),
             "Expected permission denied message, got: {}",
             display
         );
@@ -177,12 +177,12 @@ mod tests {
         let display = err.to_string();
 
         assert!(
-            display.contains("Disk full") || display.contains("ディスク"),
+            display.contains("Disk full"),
             "Expected disk full message, got: {}",
             display
         );
         assert!(
-            display.contains("Free up") || display.contains("空き"),
+            display.contains("Free up"),
             "Expected hint to free up space, got: {}",
             display
         );
@@ -196,7 +196,7 @@ mod tests {
         let display = err.to_string();
 
         assert!(
-            display.contains("Encoding") || display.contains("エンコーディング"),
+            display.contains("Encoding error"),
             "Expected encoding error message, got: {}",
             display
         );

--- a/src/export/error.rs
+++ b/src/export/error.rs
@@ -53,11 +53,7 @@ impl std::fmt::Display for ExportError {
                 )
             }
             ExportError::EncodingError { message } => {
-                write!(
-                    f,
-                    "Encoding error: {} (Try using UTF-8 encoding)",
-                    message
-                )
+                write!(f, "Encoding error: {} (Try using UTF-8 encoding)", message)
             }
         }
     }
@@ -114,7 +110,7 @@ mod tests {
     fn test_file_write_error_displays_path_and_hint() {
         let err = ExportError::FileWriteError {
             path: PathBuf::from("/tmp/test.csv"),
-            source: io::Error::new(io::ErrorKind::Other, "write failed"),
+            source: io::Error::other("write failed"),
         };
         let display = err.to_string();
 
@@ -229,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_from_io_error_fallback_to_file_write_error() {
-        let io_err = io::Error::new(io::ErrorKind::Other, "some other error");
+        let io_err = io::Error::other("some other error");
         let err = ExportError::from_io_error(io_err, PathBuf::from("/test/path"));
 
         assert!(matches!(err, ExportError::FileWriteError { .. }));

--- a/src/export/error.rs
+++ b/src/export/error.rs
@@ -1,0 +1,237 @@
+//! Export error types with user-friendly messages
+
+use std::path::PathBuf;
+
+/// Export operation errors
+#[derive(Debug)]
+pub enum ExportError {
+    /// Failed to create or write to the file
+    FileWriteError {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// Directory does not exist
+    DirectoryNotFound { path: PathBuf },
+    /// Permission denied when writing file
+    PermissionDenied { path: PathBuf },
+    /// Disk full or quota exceeded
+    DiskFull { path: PathBuf },
+    /// Encoding error
+    EncodingError { message: String },
+}
+
+impl std::fmt::Display for ExportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExportError::FileWriteError { path, source } => {
+                write!(
+                    f,
+                    "Failed to write file '{}': {} (Check file permissions and disk space)",
+                    path.display(),
+                    source
+                )
+            }
+            ExportError::DirectoryNotFound { path } => {
+                write!(
+                    f,
+                    "Directory not found: '{}' (Create the directory first or choose a different location)",
+                    path.display()
+                )
+            }
+            ExportError::PermissionDenied { path } => {
+                write!(
+                    f,
+                    "Permission denied: Cannot write to '{}' (Check file/folder permissions)",
+                    path.display()
+                )
+            }
+            ExportError::DiskFull { path } => {
+                write!(
+                    f,
+                    "Disk full: Cannot write to '{}' (Free up disk space and try again)",
+                    path.display()
+                )
+            }
+            ExportError::EncodingError { message } => {
+                write!(
+                    f,
+                    "Encoding error: {} (Try using UTF-8 encoding)",
+                    message
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ExportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ExportError::FileWriteError { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl ExportError {
+    /// Create an ExportError from an io::Error, categorizing it appropriately
+    pub fn from_io_error(err: std::io::Error, path: PathBuf) -> Self {
+        use std::io::ErrorKind;
+
+        match err.kind() {
+            ErrorKind::NotFound => ExportError::DirectoryNotFound { path },
+            ErrorKind::PermissionDenied => ExportError::PermissionDenied { path },
+            // StorageFull is not stable yet, so we check the raw_os_error
+            _ if Self::is_disk_full_error(&err) => ExportError::DiskFull { path },
+            _ => ExportError::FileWriteError { path, source: err },
+        }
+    }
+
+    /// Check if the error is a disk full error
+    fn is_disk_full_error(err: &std::io::Error) -> bool {
+        // ENOSPC on Unix, ERROR_DISK_FULL on Windows
+        #[cfg(unix)]
+        {
+            err.raw_os_error() == Some(28) // ENOSPC
+        }
+        #[cfg(windows)]
+        {
+            err.raw_os_error() == Some(112) // ERROR_DISK_FULL
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = err;
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn test_file_write_error_displays_path_and_hint() {
+        let err = ExportError::FileWriteError {
+            path: PathBuf::from("/tmp/test.csv"),
+            source: io::Error::new(io::ErrorKind::Other, "write failed"),
+        };
+        let display = err.to_string();
+
+        assert!(
+            display.contains("/tmp/test.csv"),
+            "Expected path in message, got: {}",
+            display
+        );
+        assert!(
+            display.contains("permission") || display.contains("disk"),
+            "Expected hint about permissions or disk, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_directory_not_found_displays_user_friendly_message() {
+        let err = ExportError::DirectoryNotFound {
+            path: PathBuf::from("/nonexistent/dir/file.csv"),
+        };
+        let display = err.to_string();
+
+        assert!(
+            display.contains("Directory not found") || display.contains("ディレクトリ"),
+            "Expected directory not found message, got: {}",
+            display
+        );
+        assert!(
+            display.contains("/nonexistent/dir/file.csv"),
+            "Expected path in message, got: {}",
+            display
+        );
+        assert!(
+            display.contains("Create") || display.contains("作成"),
+            "Expected hint to create directory, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_permission_denied_displays_user_friendly_message() {
+        let err = ExportError::PermissionDenied {
+            path: PathBuf::from("/protected/file.csv"),
+        };
+        let display = err.to_string();
+
+        assert!(
+            display.contains("Permission denied") || display.contains("権限"),
+            "Expected permission denied message, got: {}",
+            display
+        );
+        assert!(
+            display.contains("/protected/file.csv"),
+            "Expected path in message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_disk_full_displays_user_friendly_message() {
+        let err = ExportError::DiskFull {
+            path: PathBuf::from("/tmp/large_file.csv"),
+        };
+        let display = err.to_string();
+
+        assert!(
+            display.contains("Disk full") || display.contains("ディスク"),
+            "Expected disk full message, got: {}",
+            display
+        );
+        assert!(
+            display.contains("Free up") || display.contains("空き"),
+            "Expected hint to free up space, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_encoding_error_displays_user_friendly_message() {
+        let err = ExportError::EncodingError {
+            message: "invalid UTF-8 sequence".to_string(),
+        };
+        let display = err.to_string();
+
+        assert!(
+            display.contains("Encoding") || display.contains("エンコーディング"),
+            "Expected encoding error message, got: {}",
+            display
+        );
+        assert!(
+            display.contains("UTF-8"),
+            "Expected UTF-8 hint, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn test_from_io_error_categorizes_not_found() {
+        let io_err = io::Error::new(io::ErrorKind::NotFound, "no such file or directory");
+        let err = ExportError::from_io_error(io_err, PathBuf::from("/test/path"));
+
+        assert!(matches!(err, ExportError::DirectoryNotFound { .. }));
+    }
+
+    #[test]
+    fn test_from_io_error_categorizes_permission_denied() {
+        let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "permission denied");
+        let err = ExportError::from_io_error(io_err, PathBuf::from("/test/path"));
+
+        assert!(matches!(err, ExportError::PermissionDenied { .. }));
+    }
+
+    #[test]
+    fn test_from_io_error_fallback_to_file_write_error() {
+        let io_err = io::Error::new(io::ErrorKind::Other, "some other error");
+        let err = ExportError::from_io_error(io_err, PathBuf::from("/test/path"));
+
+        assert!(matches!(err, ExportError::FileWriteError { .. }));
+    }
+}

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -30,7 +30,10 @@
 #![allow(dead_code)]
 
 mod csv;
+mod error;
 mod json;
+
+pub use error::ExportError;
 
 use std::path::Path;
 

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -33,6 +33,8 @@ mod csv;
 mod error;
 mod json;
 
+// Re-export for future use when export is integrated with UI
+#[allow(unused_imports)]
 pub use error::ExportError;
 
 use std::path::Path;


### PR DESCRIPTION
## Summary
- ユーザーフレンドリーなエラーメッセージを実装
- 接続エラー、クエリエラー、ファイル操作エラーにヒントを追加
- デバッグ用に元のエラー詳細を保持

## Changes
- `ProviderError` の `Display` 実装を拡張し、エラーの種類に応じたヒントを表示
- `ExportError` を新規作成（将来のエクスポート機能用）
- 22件のテストを追加

## Test plan
- [x] 全テスト（186件）がパス
- [x] Clippyの警告なし
- [x] フォーマット確認済み