### PR TITLE
feat: ✨ add stored procedure and function listing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,12 +61,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: Debug - Show file contents
-        run: |
-          echo "=== provider.rs ==="
-          head -15 src/db/postgres/provider.rs
-          echo "=== trait_impl.rs line 155-175 ==="
-          sed -n '155,175p' src/db/postgres/trait_impl.rs
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -71,6 +74,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
       - name: Run tests
         run: cargo test --all-features
 
@@ -81,6 +87,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-machete
@@ -98,5 +107,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
       - name: Build release
         run: cargo build --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: "v1"
           shared-key: "rust-ci"
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -76,6 +77,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: "v1"
           shared-key: "rust-ci"
       - name: Run tests
         run: cargo test --all-features
@@ -89,6 +91,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: "v1"
           shared-key: "rust-ci"
       - uses: taiki-e/install-action@v2
         with:
@@ -109,6 +112,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: "v1"
           shared-key: "rust-ci"
       - name: Build release
         run: cargo build --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,10 +61,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v1"
-          shared-key: "rust-ci"
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -75,10 +71,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v1"
-          shared-key: "rust-ci"
       - name: Run tests
         run: cargo test --all-features
 
@@ -89,10 +81,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v1"
-          shared-key: "rust-ci"
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-machete
@@ -110,9 +98,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "v1"
-          shared-key: "rust-ci"
       - name: Build release
         run: cargo build --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - name: Debug - Show file contents
+        run: |
+          echo "=== provider.rs ==="
+          head -15 src/db/postgres/provider.rs
+          echo "=== trait_impl.rs line 155-175 ==="
+          sed -n '155,175p' src/db/postgres/trait_impl.rs
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -396,9 +396,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "fnv"
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
@@ -636,19 +636,19 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -705,9 +705,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -760,7 +760,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -965,6 +965,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -1009,9 +1018,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "scheduled-thread-pool"
@@ -1133,10 +1142,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -1226,14 +1236,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1757,6 +1767,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d6085d62852e35540689d1f97ad663e3971fc19cf5eceab364d62c646ea167"
+checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"

--- a/src/app/handlers/db.rs
+++ b/src/app/handlers/db.rs
@@ -338,6 +338,9 @@ impl App {
     }
 
     /// Send a command to fetch routines (stored procedures and functions) asynchronously
+    ///
+    /// Note: Currently uses "public" schema by default, same as table fetching.
+    /// TODO: Support configurable schema selection in connection settings.
     pub(crate) fn send_fetch_routines(
         &mut self,
         conn: &Connection,
@@ -347,6 +350,7 @@ impl App {
         let request_id = self.next_request_id();
         let connection = ConnectionParams::from_connection(conn);
 
+        // Use "public" schema by default (consistent with send_fetch_tables)
         let cmd = DbCommand::FetchRoutines {
             request_id,
             connection,

--- a/src/app/handlers/db.rs
+++ b/src/app/handlers/db.rs
@@ -2,6 +2,7 @@
 
 use crate::app::App;
 use crate::db::{ConnectionParams, DbCommand, DbResponse, DbWorkerHandle};
+use crate::model::schema::Routine;
 use crate::model::{Connection, HistoryEntry, Pagination, QueryResult, Table};
 
 impl App {
@@ -53,6 +54,9 @@ impl App {
                 ..
             } => {
                 self.handle_query_executed(result, project_idx);
+            }
+            DbResponse::RoutinesLoaded { result, target, .. } => {
+                self.handle_routines_loaded(result, target);
             }
         }
     }
@@ -301,5 +305,63 @@ impl App {
             conn_idx,
             table_idx,
         );
+    }
+
+    /// Handle routines loaded response
+    fn handle_routines_loaded(
+        &mut self,
+        result: Result<Vec<Routine>, String>,
+        target: (usize, usize),
+    ) {
+        let (proj_idx, conn_idx) = target;
+
+        // Clear loading state
+        self.loading.fetching_routines = None;
+
+        match result {
+            Ok(routines) => {
+                if let Some(project) = self.projects.get_mut(proj_idx) {
+                    if let Some(conn) = project.connections.get_mut(conn_idx) {
+                        let routine_count = routines.len();
+                        conn.routines = routines;
+                        conn.routines_loaded = true;
+                        self.status_message = format!("Loaded {} routines", routine_count);
+                        self.loading.message = None;
+                    }
+                }
+            }
+            Err(e) => {
+                self.status_message = format!("Failed to get routines: {}", e);
+                self.loading.message = None;
+            }
+        }
+    }
+
+    /// Send a command to fetch routines (stored procedures and functions) asynchronously
+    pub(crate) fn send_fetch_routines(
+        &mut self,
+        conn: &Connection,
+        proj_idx: usize,
+        conn_idx: usize,
+    ) {
+        let request_id = self.next_request_id();
+        let connection = ConnectionParams::from_connection(conn);
+
+        let cmd = DbCommand::FetchRoutines {
+            request_id,
+            connection,
+            schema: Some("public".to_string()),
+            target: (proj_idx, conn_idx),
+        };
+
+        if let Some(worker) = self.db_worker.as_ref() {
+            if worker.send(cmd).is_ok() {
+                self.loading.start_fetching_routines(conn_idx);
+            } else {
+                self.status_message = "Failed to send command to DB worker".to_string();
+            }
+        } else {
+            self.status_message = "DB worker not initialized".to_string();
+        }
     }
 }

--- a/src/app/handlers/modal.rs
+++ b/src/app/handlers/modal.rs
@@ -320,6 +320,8 @@ impl App {
             password: modal.password.clone(),
             expanded: false,
             tables: vec![],
+            routines: vec![],
+            routines_loaded: false,
         })
     }
 

--- a/src/app/handlers/sidebar.rs
+++ b/src/app/handlers/sidebar.rs
@@ -12,6 +12,7 @@ impl App {
                 self.sidebar_mode = SidebarMode::Connections(self.selected_project_idx);
                 self.selected_connection_idx = 0;
                 self.selected_table_idx = None;
+                self.selected_routine_idx = None;
                 if let Some(project) = self.projects.get(self.selected_project_idx) {
                     self.status_message = format!("Project: {}", project.name);
                 }
@@ -20,6 +21,9 @@ impl App {
                 if self.selected_table_idx.is_some() {
                     // Table selected: generate query
                     self.activate_table(proj_idx);
+                } else if self.selected_routine_idx.is_some() {
+                    // Routine selected: show routine details
+                    self.activate_routine(proj_idx);
                 } else {
                     // Connection selected: toggle expand
                     self.toggle_connection_expand(proj_idx);
@@ -39,21 +43,26 @@ impl App {
     pub(crate) fn toggle_connection_expand(&mut self, proj_idx: usize) {
         let conn_idx = self.selected_connection_idx;
 
-        // Skip if tables are already being fetched for this connection
-        if self.loading.is_fetching_tables_for(conn_idx) {
+        // Skip if tables or routines are already being fetched for this connection
+        if self.loading.is_fetching_tables_for(conn_idx)
+            || self.loading.is_fetching_routines_for(conn_idx)
+        {
             return;
         }
 
-        // First, check if we need to fetch tables (connection is being expanded and has no tables)
-        let should_fetch = if let Some(project) = self.projects.get(proj_idx) {
-            if let Some(conn) = project.connections.get(conn_idx) {
-                !conn.expanded && conn.tables.is_empty()
+        // First, check if we need to fetch tables and/or routines
+        let (should_fetch_tables, should_fetch_routines) =
+            if let Some(project) = self.projects.get(proj_idx) {
+                if let Some(conn) = project.connections.get(conn_idx) {
+                    let fetch_tables = !conn.expanded && conn.tables.is_empty();
+                    let fetch_routines = !conn.expanded && !conn.routines_loaded;
+                    (fetch_tables, fetch_routines)
+                } else {
+                    (false, false)
+                }
             } else {
-                false
-            }
-        } else {
-            false
-        };
+                (false, false)
+            };
 
         // Toggle the expanded state
         if let Some(project) = self.projects.get_mut(proj_idx) {
@@ -61,21 +70,26 @@ impl App {
                 conn.expanded = !conn.expanded;
                 if !conn.expanded {
                     self.selected_table_idx = None;
+                    self.selected_routine_idx = None;
                 }
             }
         }
 
-        // If we need to fetch tables, send async command
-        if should_fetch {
-            // Clone connection data for the async operation
-            let conn_clone = self
-                .projects
-                .get(proj_idx)
-                .and_then(|p| p.connections.get(conn_idx))
-                .cloned();
+        // Clone connection data for async operations
+        let conn_clone = self
+            .projects
+            .get(proj_idx)
+            .and_then(|p| p.connections.get(conn_idx))
+            .cloned();
 
-            if let Some(conn) = conn_clone {
+        if let Some(conn) = conn_clone {
+            // If we need to fetch tables, send async command
+            if should_fetch_tables {
                 self.send_fetch_tables(&conn, proj_idx, conn_idx);
+            }
+            // If we need to fetch routines, send async command
+            if should_fetch_routines {
+                self.send_fetch_routines(&conn, proj_idx, conn_idx);
             }
         }
     }
@@ -113,6 +127,30 @@ impl App {
         self.send_execute_query(&conn_clone, &query, proj_idx);
 
         // Move focus to main panel after selecting a table
+        self.focus = crate::app::Focus::MainPanel;
+    }
+
+    /// Activate routine: show routine definition in the detail panel
+    pub(crate) fn activate_routine(&mut self, proj_idx: usize) {
+        let conn_idx = self.selected_connection_idx;
+        let Some(routine_idx) = self.selected_routine_idx else {
+            return;
+        };
+
+        let Some(project) = self.projects.get(proj_idx) else {
+            return;
+        };
+        let Some(conn) = project.connections.get(conn_idx) else {
+            return;
+        };
+        let Some(routine) = conn.routines.get(routine_idx) else {
+            return;
+        };
+
+        // Update status message
+        self.status_message = format!("Routine: {}", routine.qualified_name());
+
+        // Move focus to main panel to show routine details
         self.focus = crate::app::Focus::MainPanel;
     }
 }

--- a/src/app/loading.rs
+++ b/src/app/loading.rs
@@ -9,6 +9,8 @@ pub struct LoadingState {
     pub fetching_tables: Option<usize>,
     /// (project_idx, connection_idx, table_idx) currently fetching table details
     pub fetching_details: Option<(usize, usize, usize)>,
+    /// Connection index currently fetching routines list
+    pub fetching_routines: Option<usize>,
     /// Whether a query is currently executing
     pub executing_query: bool,
     /// Status message to display
@@ -18,13 +20,17 @@ pub struct LoadingState {
 impl LoadingState {
     /// Returns true if any loading operation is in progress
     pub fn is_loading(&self) -> bool {
-        self.fetching_tables.is_some() || self.fetching_details.is_some() || self.executing_query
+        self.fetching_tables.is_some()
+            || self.fetching_details.is_some()
+            || self.fetching_routines.is_some()
+            || self.executing_query
     }
 
     /// Clear all loading states
     pub fn clear(&mut self) {
         self.fetching_tables = None;
         self.fetching_details = None;
+        self.fetching_routines = None;
         self.executing_query = false;
         self.message = None;
     }
@@ -65,6 +71,17 @@ impl LoadingState {
         table_idx: usize,
     ) -> bool {
         self.fetching_details == Some((proj_idx, conn_idx, table_idx))
+    }
+
+    /// Set routines fetching state for a connection
+    pub fn start_fetching_routines(&mut self, conn_idx: usize) {
+        self.fetching_routines = Some(conn_idx);
+        self.message = Some("Loading routines...".to_string());
+    }
+
+    /// Check if routines are being fetched for a specific connection
+    pub fn is_fetching_routines_for(&self, conn_idx: usize) -> bool {
+        self.fetching_routines == Some(conn_idx)
     }
 }
 
@@ -117,6 +134,7 @@ mod tests {
         let mut state = LoadingState {
             fetching_tables: Some(0),
             fetching_details: Some((0, 1, 2)),
+            fetching_routines: Some(1),
             executing_query: true,
             message: Some("test".to_string()),
         };
@@ -126,6 +144,7 @@ mod tests {
         assert!(!state.is_loading());
         assert!(state.fetching_tables.is_none());
         assert!(state.fetching_details.is_none());
+        assert!(state.fetching_routines.is_none());
         assert!(!state.executing_query);
         assert!(state.message.is_none());
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -22,6 +22,7 @@ pub struct App {
     pub selected_project_idx: usize,
     pub selected_connection_idx: usize,
     pub selected_table_idx: Option<usize>,
+    pub selected_routine_idx: Option<usize>,
     pub query: String,
     pub result: Option<QueryResult>,
     pub pagination: Pagination,
@@ -58,6 +59,7 @@ impl App {
             selected_project_idx: 0,
             selected_connection_idx: 0,
             selected_table_idx: None,
+            selected_routine_idx: None,
             query: String::new(),
             result: None,
             pagination: Pagination::default(),
@@ -85,6 +87,7 @@ impl App {
             selected_project_idx: 0,
             selected_connection_idx: 0,
             selected_table_idx: None,
+            selected_routine_idx: None,
             query: String::new(),
             result: None,
             pagination: Pagination::default(),
@@ -128,6 +131,18 @@ impl App {
             let conn = project.connections.get(self.selected_connection_idx)?;
             let table_idx = self.selected_table_idx?;
             conn.tables.get(table_idx)
+        } else {
+            None
+        }
+    }
+
+    /// Get currently selected routine (stored procedure/function) if any
+    pub fn selected_routine_info(&self) -> Option<&crate::model::schema::Routine> {
+        if let SidebarMode::Connections(proj_idx) = self.sidebar_mode {
+            let project = self.projects.get(proj_idx)?;
+            let conn = project.connections.get(self.selected_connection_idx)?;
+            let routine_idx = self.selected_routine_idx?;
+            conn.routines.get(routine_idx)
         } else {
             None
         }
@@ -805,6 +820,8 @@ mod tests {
                 password: "".to_string(),
                 database: "db".to_string(),
                 tables: vec![],
+                routines: vec![],
+                routines_loaded: false,
                 expanded: false,
             },
             Connection {
@@ -815,6 +832,8 @@ mod tests {
                 password: "".to_string(),
                 database: "db".to_string(),
                 tables: vec![],
+                routines: vec![],
+                routines_loaded: false,
                 expanded: false,
             },
             Connection {
@@ -825,6 +844,8 @@ mod tests {
                 password: "".to_string(),
                 database: "db".to_string(),
                 tables: vec![],
+                routines: vec![],
+                routines_loaded: false,
                 expanded: false,
             },
         ]

--- a/src/db/postgres/queries/mod.rs
+++ b/src/db/postgres/queries/mod.rs
@@ -6,12 +6,13 @@ mod columns;
 mod constraints;
 mod foreign_keys;
 mod indexes;
+mod routines;
 mod stats;
 mod triggers;
 
 use postgres::Client;
 
-use crate::model::schema::{Column, Constraint, ForeignKey, Index, Trigger};
+use crate::model::schema::{Column, Constraint, ForeignKey, Index, Routine, Trigger};
 
 use super::ProviderError;
 
@@ -81,5 +82,13 @@ impl InternalQueries {
         schema: &str,
     ) -> Result<Vec<Trigger>, ProviderError> {
         triggers::get_triggers(client, table_name, schema)
+    }
+
+    /// Retrieves all stored procedures and functions from the specified schema.
+    pub fn get_routines(
+        client: &mut Client,
+        schema: &str,
+    ) -> Result<Vec<Routine>, ProviderError> {
+        routines::get_routines(client, schema)
     }
 }

--- a/src/db/postgres/queries/mod.rs
+++ b/src/db/postgres/queries/mod.rs
@@ -85,10 +85,7 @@ impl InternalQueries {
     }
 
     /// Retrieves all stored procedures and functions from the specified schema.
-    pub fn get_routines(
-        client: &mut Client,
-        schema: &str,
-    ) -> Result<Vec<Routine>, ProviderError> {
+    pub fn get_routines(client: &mut Client, schema: &str) -> Result<Vec<Routine>, ProviderError> {
         routines::get_routines(client, schema)
     }
 }

--- a/src/db/postgres/queries/routines.rs
+++ b/src/db/postgres/queries/routines.rs
@@ -48,7 +48,10 @@ pub fn get_routines(client: &mut Client, schema: &str) -> Result<Vec<Routine>, P
         .map_err(|e| ProviderError::QueryFailed(e.to_string()))?;
 
     // Collect routine OIDs for batch parameter fetch
-    let routine_oids: Vec<u32> = routine_rows.iter().map(|row| row.get::<_, u32>(9)).collect();
+    let routine_oids: Vec<u32> = routine_rows
+        .iter()
+        .map(|row| row.get::<_, u32>(9))
+        .collect();
 
     // Fetch all parameters in one query and group by routine OID
     let params_map = fetch_all_parameters(client, &routine_oids)?;
@@ -79,10 +82,7 @@ pub fn get_routines(client: &mut Client, schema: &str) -> Result<Vec<Routine>, P
         };
 
         // Get parameters from the pre-fetched map
-        let parameters = params_map
-            .get(&routine_oid)
-            .cloned()
-            .unwrap_or_default();
+        let parameters = params_map.get(&routine_oid).cloned().unwrap_or_default();
 
         let mut routine =
             Routine::new(name, schema_name, routine_type, language).with_volatility(volatility);

--- a/src/db/postgres/queries/routines.rs
+++ b/src/db/postgres/queries/routines.rs
@@ -1,5 +1,7 @@
 //! Routine (stored procedures and functions) metadata query
 
+use std::collections::HashMap;
+
 use postgres::Client;
 
 use crate::db::postgres::ProviderError;
@@ -8,7 +10,7 @@ use crate::model::schema::{ParameterMode, Routine, RoutineParameter, RoutineType
 /// Retrieves all stored procedures and functions from the specified schema.
 pub fn get_routines(client: &mut Client, schema: &str) -> Result<Vec<Routine>, ProviderError> {
     // Query to get all routines (functions and procedures) with their metadata
-    let query = r#"
+    let routines_query = r#"
         SELECT
             p.proname AS routine_name,
             n.nspname AS schema_name,
@@ -41,13 +43,19 @@ pub fn get_routines(client: &mut Client, schema: &str) -> Result<Vec<Routine>, P
         ORDER BY p.proname
     "#;
 
-    let rows = client
-        .query(query, &[&schema])
+    let routine_rows = client
+        .query(routines_query, &[&schema])
         .map_err(|e| ProviderError::QueryFailed(e.to_string()))?;
+
+    // Collect routine OIDs for batch parameter fetch
+    let routine_oids: Vec<u32> = routine_rows.iter().map(|row| row.get::<_, u32>(9)).collect();
+
+    // Fetch all parameters in one query and group by routine OID
+    let params_map = fetch_all_parameters(client, &routine_oids)?;
 
     let mut routines = Vec::new();
 
-    for row in rows {
+    for row in routine_rows {
         let name: String = row.get(0);
         let schema_name: String = row.get(1);
         let routine_type_str: String = row.get(2);
@@ -70,8 +78,11 @@ pub fn get_routines(client: &mut Client, schema: &str) -> Result<Vec<Routine>, P
             _ => Volatility::Volatile,
         };
 
-        // Get parameters for this routine
-        let parameters = get_routine_parameters(client, routine_oid)?;
+        // Get parameters from the pre-fetched map
+        let parameters = params_map
+            .get(&routine_oid)
+            .cloned()
+            .unwrap_or_default();
 
         let mut routine =
             Routine::new(name, schema_name, routine_type, language).with_volatility(volatility);
@@ -103,60 +114,83 @@ pub fn get_routines(client: &mut Client, schema: &str) -> Result<Vec<Routine>, P
     Ok(routines)
 }
 
-/// Retrieves parameters for a specific routine by its OID.
-fn get_routine_parameters(
+/// Fetch all parameters for given routine OIDs in a single query.
+/// Returns a HashMap mapping routine OID to its parameters.
+fn fetch_all_parameters(
     client: &mut Client,
-    routine_oid: u32,
-) -> Result<Vec<RoutineParameter>, ProviderError> {
+    routine_oids: &[u32],
+) -> Result<HashMap<u32, Vec<RoutineParameter>>, ProviderError> {
+    if routine_oids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Use pg_proc directly to get parameter information
+    // This is more reliable than information_schema.parameters
     let query = r#"
-        SELECT
-            COALESCE(p.parameter_name, '') AS param_name,
-            p.data_type,
-            p.parameter_mode,
-            p.parameter_default,
-            p.ordinal_position
-        FROM information_schema.parameters p
-        WHERE p.specific_schema || '.' || p.specific_name = (
-            SELECT n.nspname || '.' || p2.proname || '_' || p2.oid::text
-            FROM pg_proc p2
-            JOIN pg_namespace n ON n.oid = p2.pronamespace
-            WHERE p2.oid = $1
+        WITH routine_params AS (
+            SELECT
+                p.oid AS routine_oid,
+                unnest(COALESCE(p.proargnames, ARRAY[]::text[])) AS param_name,
+                unnest(COALESCE(p.proargmodes, ARRAY['i']::char[])) AS param_mode,
+                unnest(string_to_array(pg_get_function_identity_arguments(p.oid), ', ')) AS param_sig,
+                generate_series(1, COALESCE(array_length(p.proargnames, 1), pronargs)) AS ordinal
+            FROM pg_proc p
+            WHERE p.oid = ANY($1::oid[])
         )
-        ORDER BY p.ordinal_position
+        SELECT
+            routine_oid,
+            COALESCE(param_name, '') AS param_name,
+            CASE param_mode
+                WHEN 'i' THEN 'IN'
+                WHEN 'o' THEN 'OUT'
+                WHEN 'b' THEN 'INOUT'
+                WHEN 'v' THEN 'VARIADIC'
+                WHEN 't' THEN 'TABLE'
+                ELSE 'IN'
+            END AS param_mode,
+            -- Extract type from signature (format: "name type" or just "type")
+            CASE
+                WHEN param_sig ~ ' ' THEN regexp_replace(param_sig, '^[^ ]+ ', '')
+                ELSE param_sig
+            END AS data_type,
+            ordinal
+        FROM routine_params
+        WHERE param_sig IS NOT NULL AND param_sig != ''
+        ORDER BY routine_oid, ordinal
     "#;
 
+    let oids_i64: Vec<i64> = routine_oids.iter().map(|&oid| oid as i64).collect();
+
     let rows = client
-        .query(query, &[&(routine_oid as i32)])
+        .query(query, &[&oids_i64])
         .map_err(|e| ProviderError::QueryFailed(e.to_string()))?;
 
-    let parameters = rows
-        .iter()
-        .map(|row| {
-            let name: String = row.get(0);
-            let data_type: String = row.get(1);
-            let mode_str: String = row.get(2);
-            let default_value: Option<String> = row.get(3);
-            let ordinal_position: i32 = row.get(4);
+    let mut params_map: HashMap<u32, Vec<RoutineParameter>> = HashMap::new();
 
-            let mode = match mode_str.as_str() {
-                "OUT" => ParameterMode::Out,
-                "INOUT" => ParameterMode::InOut,
-                "VARIADIC" => ParameterMode::Variadic,
-                _ => ParameterMode::In,
-            };
+    for row in rows {
+        let routine_oid: i64 = row.get(0);
+        let name: String = row.get(1);
+        let mode_str: String = row.get(2);
+        let data_type: String = row.get(3);
+        let ordinal: i32 = row.get(4);
 
-            let mut param = RoutineParameter::new(name, data_type, mode)
-                .with_position(ordinal_position as u32);
+        let mode = match mode_str.as_str() {
+            "OUT" => ParameterMode::Out,
+            "INOUT" => ParameterMode::InOut,
+            "VARIADIC" => ParameterMode::Variadic,
+            "TABLE" => ParameterMode::Out, // TABLE parameters are similar to OUT
+            _ => ParameterMode::In,
+        };
 
-            if let Some(def) = default_value {
-                param = param.with_default(def);
-            }
+        let param = RoutineParameter::new(name, data_type, mode).with_position(ordinal as u32);
 
-            param
-        })
-        .collect();
+        params_map
+            .entry(routine_oid as u32)
+            .or_default()
+            .push(param);
+    }
 
-    Ok(parameters)
+    Ok(params_map)
 }
 
 #[cfg(test)]

--- a/src/db/postgres/queries/routines.rs
+++ b/src/db/postgres/queries/routines.rs
@@ -1,0 +1,260 @@
+//! Routine (stored procedures and functions) metadata query
+
+use postgres::Client;
+
+use crate::db::postgres::ProviderError;
+use crate::model::schema::{ParameterMode, Routine, RoutineParameter, RoutineType, Volatility};
+
+/// Retrieves all stored procedures and functions from the specified schema.
+pub fn get_routines(client: &mut Client, schema: &str) -> Result<Vec<Routine>, ProviderError> {
+    // Query to get all routines (functions and procedures) with their metadata
+    let query = r#"
+        SELECT
+            p.proname AS routine_name,
+            n.nspname AS schema_name,
+            CASE p.prokind
+                WHEN 'f' THEN 'FUNCTION'
+                WHEN 'p' THEN 'PROCEDURE'
+                WHEN 'a' THEN 'FUNCTION'  -- aggregate functions
+                WHEN 'w' THEN 'FUNCTION'  -- window functions
+                ELSE 'FUNCTION'
+            END AS routine_type,
+            l.lanname AS language,
+            CASE p.provolatile
+                WHEN 'i' THEN 'IMMUTABLE'
+                WHEN 's' THEN 'STABLE'
+                ELSE 'VOLATILE'
+            END AS volatility,
+            p.prosecdef AS security_definer,
+            pg_get_function_result(p.oid) AS return_type,
+            pg_get_functiondef(p.oid) AS definition,
+            d.description AS comment,
+            p.oid AS routine_oid
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        JOIN pg_language l ON l.oid = p.prolang
+        LEFT JOIN pg_description d ON d.objoid = p.oid AND d.classoid = 'pg_proc'::regclass
+        WHERE n.nspname = $1
+        AND p.prokind IN ('f', 'p', 'a', 'w')  -- functions, procedures, aggregates, windows
+        AND l.lanname != 'internal'  -- exclude internal functions
+        AND l.lanname != 'c'  -- exclude C functions
+        ORDER BY p.proname
+    "#;
+
+    let rows = client
+        .query(query, &[&schema])
+        .map_err(|e| ProviderError::QueryFailed(e.to_string()))?;
+
+    let mut routines = Vec::new();
+
+    for row in rows {
+        let name: String = row.get(0);
+        let schema_name: String = row.get(1);
+        let routine_type_str: String = row.get(2);
+        let language: String = row.get(3);
+        let volatility_str: String = row.get(4);
+        let security_definer: bool = row.get(5);
+        let return_type: Option<String> = row.get(6);
+        let definition: Option<String> = row.get(7);
+        let comment: Option<String> = row.get(8);
+        let routine_oid: u32 = row.get(9);
+
+        let routine_type = match routine_type_str.as_str() {
+            "PROCEDURE" => RoutineType::Procedure,
+            _ => RoutineType::Function,
+        };
+
+        let volatility = match volatility_str.as_str() {
+            "IMMUTABLE" => Volatility::Immutable,
+            "STABLE" => Volatility::Stable,
+            _ => Volatility::Volatile,
+        };
+
+        // Get parameters for this routine
+        let parameters = get_routine_parameters(client, routine_oid)?;
+
+        let mut routine =
+            Routine::new(name, schema_name, routine_type, language).with_volatility(volatility);
+
+        if security_definer {
+            routine = routine.with_security_definer(true);
+        }
+
+        if let Some(ret) = return_type {
+            // Procedures return void, so we only set return_type for functions with non-void returns
+            if ret != "void" {
+                routine = routine.with_return_type(ret);
+            }
+        }
+
+        if let Some(def) = definition {
+            routine = routine.with_definition(def);
+        }
+
+        if let Some(cmt) = comment {
+            routine = routine.with_comment(cmt);
+        }
+
+        routine = routine.with_parameters(parameters);
+
+        routines.push(routine);
+    }
+
+    Ok(routines)
+}
+
+/// Retrieves parameters for a specific routine by its OID.
+fn get_routine_parameters(
+    client: &mut Client,
+    routine_oid: u32,
+) -> Result<Vec<RoutineParameter>, ProviderError> {
+    let query = r#"
+        SELECT
+            COALESCE(p.parameter_name, '') AS param_name,
+            p.data_type,
+            p.parameter_mode,
+            p.parameter_default,
+            p.ordinal_position
+        FROM information_schema.parameters p
+        WHERE p.specific_schema || '.' || p.specific_name = (
+            SELECT n.nspname || '.' || p2.proname || '_' || p2.oid::text
+            FROM pg_proc p2
+            JOIN pg_namespace n ON n.oid = p2.pronamespace
+            WHERE p2.oid = $1
+        )
+        ORDER BY p.ordinal_position
+    "#;
+
+    let rows = client
+        .query(query, &[&(routine_oid as i32)])
+        .map_err(|e| ProviderError::QueryFailed(e.to_string()))?;
+
+    let parameters = rows
+        .iter()
+        .map(|row| {
+            let name: String = row.get(0);
+            let data_type: String = row.get(1);
+            let mode_str: String = row.get(2);
+            let default_value: Option<String> = row.get(3);
+            let ordinal_position: i32 = row.get(4);
+
+            let mode = match mode_str.as_str() {
+                "OUT" => ParameterMode::Out,
+                "INOUT" => ParameterMode::InOut,
+                "VARIADIC" => ParameterMode::Variadic,
+                _ => ParameterMode::In,
+            };
+
+            let mut param = RoutineParameter::new(name, data_type, mode)
+                .with_position(ordinal_position as u32);
+
+            if let Some(def) = default_value {
+                param = param.with_default(def);
+            }
+
+            param
+        })
+        .collect();
+
+    Ok(parameters)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: These are unit tests for parsing logic.
+    // Integration tests with actual PostgreSQL are in the tests/ directory.
+
+    #[test]
+    fn test_routine_type_parsing() {
+        assert!(matches!(
+            match "PROCEDURE" {
+                "PROCEDURE" => RoutineType::Procedure,
+                _ => RoutineType::Function,
+            },
+            RoutineType::Procedure
+        ));
+
+        assert!(matches!(
+            match "FUNCTION" {
+                "PROCEDURE" => RoutineType::Procedure,
+                _ => RoutineType::Function,
+            },
+            RoutineType::Function
+        ));
+    }
+
+    #[test]
+    fn test_volatility_parsing() {
+        assert!(matches!(
+            match "IMMUTABLE" {
+                "IMMUTABLE" => Volatility::Immutable,
+                "STABLE" => Volatility::Stable,
+                _ => Volatility::Volatile,
+            },
+            Volatility::Immutable
+        ));
+
+        assert!(matches!(
+            match "STABLE" {
+                "IMMUTABLE" => Volatility::Immutable,
+                "STABLE" => Volatility::Stable,
+                _ => Volatility::Volatile,
+            },
+            Volatility::Stable
+        ));
+
+        assert!(matches!(
+            match "VOLATILE" {
+                "IMMUTABLE" => Volatility::Immutable,
+                "STABLE" => Volatility::Stable,
+                _ => Volatility::Volatile,
+            },
+            Volatility::Volatile
+        ));
+    }
+
+    #[test]
+    fn test_parameter_mode_parsing() {
+        assert!(matches!(
+            match "IN" {
+                "OUT" => ParameterMode::Out,
+                "INOUT" => ParameterMode::InOut,
+                "VARIADIC" => ParameterMode::Variadic,
+                _ => ParameterMode::In,
+            },
+            ParameterMode::In
+        ));
+
+        assert!(matches!(
+            match "OUT" {
+                "OUT" => ParameterMode::Out,
+                "INOUT" => ParameterMode::InOut,
+                "VARIADIC" => ParameterMode::Variadic,
+                _ => ParameterMode::In,
+            },
+            ParameterMode::Out
+        ));
+
+        assert!(matches!(
+            match "INOUT" {
+                "OUT" => ParameterMode::Out,
+                "INOUT" => ParameterMode::InOut,
+                "VARIADIC" => ParameterMode::Variadic,
+                _ => ParameterMode::In,
+            },
+            ParameterMode::InOut
+        ));
+
+        assert!(matches!(
+            match "VARIADIC" {
+                "OUT" => ParameterMode::Out,
+                "INOUT" => ParameterMode::InOut,
+                "VARIADIC" => ParameterMode::Variadic,
+                _ => ParameterMode::In,
+            },
+            ParameterMode::Variadic
+        ));
+    }
+}

--- a/src/db/postgres/trait_impl.rs
+++ b/src/db/postgres/trait_impl.rs
@@ -156,9 +156,7 @@ impl DatabaseProvider for PostgresProvider {
     fn get_routines(&self, schema: Option<&str>) -> Result<Vec<Routine>, ProviderError> {
         let schema_str = schema.unwrap_or("public");
 
-        let mut client = self.client.lock().map_err(|e| {
-            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
-        })?;
+        let mut client = self.get_connection()?;
 
         InternalQueries::get_routines(&mut client, schema_str)
     }

--- a/src/db/postgres/trait_impl.rs
+++ b/src/db/postgres/trait_impl.rs
@@ -2,7 +2,7 @@
 
 use std::time::Instant;
 
-use crate::model::schema::{Table, TableType};
+use crate::model::schema::{Routine, Table, TableType};
 use crate::model::QueryResult;
 
 use super::helpers::{convert_value_to_string, is_valid_identifier, quote_identifier};
@@ -151,6 +151,16 @@ impl DatabaseProvider for PostgresProvider {
         table.comment = comment;
 
         Ok(table)
+    }
+
+    fn get_routines(&self, schema: Option<&str>) -> Result<Vec<Routine>, ProviderError> {
+        let schema_str = schema.unwrap_or("public");
+
+        let mut client = self.client.lock().map_err(|e| {
+            ProviderError::InternalError(format!("Failed to acquire client lock: {}", e))
+        })?;
+
+        InternalQueries::get_routines(&mut client, schema_str)
     }
 
     fn execute_query(&self, query: &str) -> Result<QueryResult, ProviderError> {

--- a/src/db/provider.rs
+++ b/src/db/provider.rs
@@ -1,4 +1,4 @@
-use crate::model::schema::{Column, Constraint, ForeignKey, Index, Table};
+use crate::model::schema::{Column, Constraint, ForeignKey, Index, Routine, Table};
 use crate::model::QueryResult;
 
 /// Supported database types
@@ -122,6 +122,12 @@ pub trait DatabaseProvider: Send + Sync {
     ) -> Result<Vec<Constraint>, ProviderError> {
         Ok(self.get_table_details(table_name, schema)?.constraints)
     }
+
+    /// Get stored procedures and functions in a schema.
+    ///
+    /// Returns all user-defined functions and procedures excluding internal
+    /// and C language functions.
+    fn get_routines(&self, schema: Option<&str>) -> Result<Vec<Routine>, ProviderError>;
 
     /// Execute a query and return results
     fn execute_query(&self, query: &str) -> Result<QueryResult, ProviderError>;

--- a/src/model/connection.rs
+++ b/src/model/connection.rs
@@ -1,4 +1,4 @@
-use super::schema::Table;
+use super::schema::{Routine, Table};
 use crate::config::ConnectionConfig;
 
 #[derive(Debug, Clone)]
@@ -11,6 +11,10 @@ pub struct Connection {
     pub password: String,
     pub expanded: bool,
     pub tables: Vec<Table>,
+    /// Stored procedures and functions
+    pub routines: Vec<Routine>,
+    /// Whether routines have been loaded
+    pub routines_loaded: bool,
 }
 
 impl From<ConnectionConfig> for Connection {
@@ -25,6 +29,8 @@ impl From<ConnectionConfig> for Connection {
             password,
             expanded: false,
             tables: Vec::new(),
+            routines: Vec::new(),
+            routines_loaded: false,
         }
     }
 }

--- a/src/model/schema/mod.rs
+++ b/src/model/schema/mod.rs
@@ -6,6 +6,7 @@ mod column;
 mod constraint;
 mod foreign_key;
 mod index;
+mod routine;
 mod table;
 mod trigger;
 
@@ -13,5 +14,6 @@ pub use column::Column;
 pub use constraint::{Constraint, ConstraintType};
 pub use foreign_key::{ForeignKey, ForeignKeyAction};
 pub use index::{Index, IndexColumn, IndexMethod, IndexType, SortOrder};
+pub use routine::{ParameterMode, Routine, RoutineParameter, RoutineType, Volatility};
 pub use table::{Table, TableType};
 pub use trigger::{Trigger, TriggerEvent, TriggerOrientation, TriggerTiming};

--- a/src/model/schema/routine.rs
+++ b/src/model/schema/routine.rs
@@ -281,8 +281,7 @@ mod tests {
 
     #[test]
     fn test_routine_parameter_with_position() {
-        let param =
-            RoutineParameter::new("user_id", "integer", ParameterMode::In).with_position(1);
+        let param = RoutineParameter::new("user_id", "integer", ParameterMode::In).with_position(1);
 
         assert_eq!(param.ordinal_position, 1);
     }
@@ -390,10 +389,7 @@ mod tests {
         let routine = Routine::new("get_user", "public", RoutineType::Function, "plpgsql")
             .with_comment("Retrieves a user by ID");
 
-        assert_eq!(
-            routine.comment,
-            Some("Retrieves a user by ID".to_string())
-        );
+        assert_eq!(routine.comment, Some("Retrieves a user by ID".to_string()));
     }
 
     #[test]
@@ -412,8 +408,10 @@ mod tests {
 
     #[test]
     fn test_routine_parameters_signature_single() {
-        let routine = Routine::new("get_user", "public", RoutineType::Function, "sql")
-            .with_parameter(RoutineParameter::new("user_id", "integer", ParameterMode::In));
+        let routine =
+            Routine::new("get_user", "public", RoutineType::Function, "sql").with_parameter(
+                RoutineParameter::new("user_id", "integer", ParameterMode::In),
+            );
 
         assert_eq!(routine.parameters_signature(), "(user_id integer)");
     }
@@ -421,8 +419,16 @@ mod tests {
     #[test]
     fn test_routine_parameters_signature_multiple() {
         let routine = Routine::new("get_users", "public", RoutineType::Function, "sql")
-            .with_parameter(RoutineParameter::new("offset_val", "integer", ParameterMode::In))
-            .with_parameter(RoutineParameter::new("limit_val", "integer", ParameterMode::In));
+            .with_parameter(RoutineParameter::new(
+                "offset_val",
+                "integer",
+                ParameterMode::In,
+            ))
+            .with_parameter(RoutineParameter::new(
+                "limit_val",
+                "integer",
+                ParameterMode::In,
+            ));
 
         assert_eq!(
             routine.parameters_signature(),
@@ -432,9 +438,22 @@ mod tests {
 
     #[test]
     fn test_routine_parameters_signature_excludes_out_params() {
-        let routine = Routine::new("get_user_with_count", "public", RoutineType::Function, "sql")
-            .with_parameter(RoutineParameter::new("user_id", "integer", ParameterMode::In))
-            .with_parameter(RoutineParameter::new("total_count", "integer", ParameterMode::Out));
+        let routine = Routine::new(
+            "get_user_with_count",
+            "public",
+            RoutineType::Function,
+            "sql",
+        )
+        .with_parameter(RoutineParameter::new(
+            "user_id",
+            "integer",
+            ParameterMode::In,
+        ))
+        .with_parameter(RoutineParameter::new(
+            "total_count",
+            "integer",
+            ParameterMode::Out,
+        ));
 
         assert_eq!(routine.parameters_signature(), "(user_id integer)");
     }
@@ -463,18 +482,23 @@ mod tests {
 
     #[test]
     fn test_routine_full_builder() {
-        let routine = Routine::new("calculate_total", "billing", RoutineType::Function, "plpgsql")
-            .with_parameters(vec![
-                RoutineParameter::new("order_id", "integer", ParameterMode::In).with_position(1),
-                RoutineParameter::new("include_tax", "boolean", ParameterMode::In)
-                    .with_default("true")
-                    .with_position(2),
-            ])
-            .with_return_type("numeric")
-            .with_volatility(Volatility::Stable)
-            .with_security_definer(false)
-            .with_definition("CREATE FUNCTION calculate_total...")
-            .with_comment("Calculates the total amount for an order");
+        let routine = Routine::new(
+            "calculate_total",
+            "billing",
+            RoutineType::Function,
+            "plpgsql",
+        )
+        .with_parameters(vec![
+            RoutineParameter::new("order_id", "integer", ParameterMode::In).with_position(1),
+            RoutineParameter::new("include_tax", "boolean", ParameterMode::In)
+                .with_default("true")
+                .with_position(2),
+        ])
+        .with_return_type("numeric")
+        .with_volatility(Volatility::Stable)
+        .with_security_definer(false)
+        .with_definition("CREATE FUNCTION calculate_total...")
+        .with_comment("Calculates the total amount for an order");
 
         assert_eq!(routine.name, "calculate_total");
         assert_eq!(routine.schema, "billing");

--- a/src/model/schema/routine.rs
+++ b/src/model/schema/routine.rs
@@ -1,0 +1,493 @@
+//! Routine types and structures (stored procedures and functions)
+
+/// Routine type (procedure or function)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoutineType {
+    Procedure,
+    Function,
+}
+
+impl std::fmt::Display for RoutineType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RoutineType::Procedure => write!(f, "PROCEDURE"),
+            RoutineType::Function => write!(f, "FUNCTION"),
+        }
+    }
+}
+
+/// Parameter mode (IN, OUT, INOUT, VARIADIC)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParameterMode {
+    In,
+    Out,
+    InOut,
+    Variadic,
+}
+
+impl std::fmt::Display for ParameterMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParameterMode::In => write!(f, "IN"),
+            ParameterMode::Out => write!(f, "OUT"),
+            ParameterMode::InOut => write!(f, "INOUT"),
+            ParameterMode::Variadic => write!(f, "VARIADIC"),
+        }
+    }
+}
+
+/// Routine parameter information
+#[derive(Debug, Clone, PartialEq)]
+pub struct RoutineParameter {
+    /// Parameter name (may be empty for unnamed parameters)
+    pub name: String,
+    /// Parameter data type
+    pub data_type: String,
+    /// Parameter mode
+    pub mode: ParameterMode,
+    /// Default value (if any)
+    pub default_value: Option<String>,
+    /// Ordinal position (1-based)
+    pub ordinal_position: u32,
+}
+
+impl RoutineParameter {
+    /// Create a new parameter with required fields
+    pub fn new(name: impl Into<String>, data_type: impl Into<String>, mode: ParameterMode) -> Self {
+        Self {
+            name: name.into(),
+            data_type: data_type.into(),
+            mode,
+            default_value: None,
+            ordinal_position: 0,
+        }
+    }
+
+    /// Set the default value
+    pub fn with_default(mut self, default: impl Into<String>) -> Self {
+        self.default_value = Some(default.into());
+        self
+    }
+
+    /// Set the ordinal position
+    pub fn with_position(mut self, position: u32) -> Self {
+        self.ordinal_position = position;
+        self
+    }
+}
+
+/// Routine volatility category
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Volatility {
+    Immutable,
+    Stable,
+    Volatile,
+}
+
+impl std::fmt::Display for Volatility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Volatility::Immutable => write!(f, "IMMUTABLE"),
+            Volatility::Stable => write!(f, "STABLE"),
+            Volatility::Volatile => write!(f, "VOLATILE"),
+        }
+    }
+}
+
+/// Database routine (stored procedure or function)
+#[derive(Debug, Clone, PartialEq)]
+pub struct Routine {
+    /// Routine name
+    pub name: String,
+    /// Schema name
+    pub schema: String,
+    /// Routine type (procedure or function)
+    pub routine_type: RoutineType,
+    /// Parameters
+    pub parameters: Vec<RoutineParameter>,
+    /// Return type (for functions; None for procedures)
+    pub return_type: Option<String>,
+    /// Language (e.g., plpgsql, sql, python)
+    pub language: String,
+    /// Volatility category
+    pub volatility: Volatility,
+    /// Whether the routine is security definer
+    pub security_definer: bool,
+    /// Full routine definition (CREATE FUNCTION/PROCEDURE statement)
+    pub definition: Option<String>,
+    /// Description/comment
+    pub comment: Option<String>,
+}
+
+impl Routine {
+    /// Create a new routine with required fields
+    pub fn new(
+        name: impl Into<String>,
+        schema: impl Into<String>,
+        routine_type: RoutineType,
+        language: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            schema: schema.into(),
+            routine_type,
+            parameters: Vec::new(),
+            return_type: None,
+            language: language.into(),
+            volatility: Volatility::Volatile,
+            security_definer: false,
+            definition: None,
+            comment: None,
+        }
+    }
+
+    /// Add a parameter
+    pub fn with_parameter(mut self, param: RoutineParameter) -> Self {
+        self.parameters.push(param);
+        self
+    }
+
+    /// Set multiple parameters
+    pub fn with_parameters(mut self, params: Vec<RoutineParameter>) -> Self {
+        self.parameters = params;
+        self
+    }
+
+    /// Set the return type
+    pub fn with_return_type(mut self, return_type: impl Into<String>) -> Self {
+        self.return_type = Some(return_type.into());
+        self
+    }
+
+    /// Set volatility
+    pub fn with_volatility(mut self, volatility: Volatility) -> Self {
+        self.volatility = volatility;
+        self
+    }
+
+    /// Set security definer
+    pub fn with_security_definer(mut self, security_definer: bool) -> Self {
+        self.security_definer = security_definer;
+        self
+    }
+
+    /// Set the definition
+    pub fn with_definition(mut self, definition: impl Into<String>) -> Self {
+        self.definition = Some(definition.into());
+        self
+    }
+
+    /// Set the comment
+    pub fn with_comment(mut self, comment: impl Into<String>) -> Self {
+        self.comment = Some(comment.into());
+        self
+    }
+
+    /// Get display name with schema (e.g., "public.my_function")
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", self.schema, self.name)
+    }
+
+    /// Get parameter signature string (e.g., "(id integer, name text)")
+    pub fn parameters_signature(&self) -> String {
+        if self.parameters.is_empty() {
+            return "()".to_string();
+        }
+
+        let params: Vec<String> = self
+            .parameters
+            .iter()
+            .filter(|p| p.mode != ParameterMode::Out)
+            .map(|p| {
+                if p.name.is_empty() {
+                    p.data_type.clone()
+                } else {
+                    format!("{} {}", p.name, p.data_type)
+                }
+            })
+            .collect();
+
+        format!("({})", params.join(", "))
+    }
+
+    /// Check if this is a function
+    pub fn is_function(&self) -> bool {
+        self.routine_type == RoutineType::Function
+    }
+
+    /// Check if this is a procedure
+    pub fn is_procedure(&self) -> bool {
+        self.routine_type == RoutineType::Procedure
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== RoutineType tests =====
+
+    #[test]
+    fn test_routine_type_display_procedure() {
+        assert_eq!(RoutineType::Procedure.to_string(), "PROCEDURE");
+    }
+
+    #[test]
+    fn test_routine_type_display_function() {
+        assert_eq!(RoutineType::Function.to_string(), "FUNCTION");
+    }
+
+    // ===== ParameterMode tests =====
+
+    #[test]
+    fn test_parameter_mode_display_in() {
+        assert_eq!(ParameterMode::In.to_string(), "IN");
+    }
+
+    #[test]
+    fn test_parameter_mode_display_out() {
+        assert_eq!(ParameterMode::Out.to_string(), "OUT");
+    }
+
+    #[test]
+    fn test_parameter_mode_display_inout() {
+        assert_eq!(ParameterMode::InOut.to_string(), "INOUT");
+    }
+
+    #[test]
+    fn test_parameter_mode_display_variadic() {
+        assert_eq!(ParameterMode::Variadic.to_string(), "VARIADIC");
+    }
+
+    // ===== RoutineParameter tests =====
+
+    #[test]
+    fn test_routine_parameter_new() {
+        let param = RoutineParameter::new("user_id", "integer", ParameterMode::In);
+
+        assert_eq!(param.name, "user_id");
+        assert_eq!(param.data_type, "integer");
+        assert_eq!(param.mode, ParameterMode::In);
+        assert!(param.default_value.is_none());
+        assert_eq!(param.ordinal_position, 0);
+    }
+
+    #[test]
+    fn test_routine_parameter_with_default() {
+        let param = RoutineParameter::new("limit", "integer", ParameterMode::In).with_default("10");
+
+        assert_eq!(param.default_value, Some("10".to_string()));
+    }
+
+    #[test]
+    fn test_routine_parameter_with_position() {
+        let param =
+            RoutineParameter::new("user_id", "integer", ParameterMode::In).with_position(1);
+
+        assert_eq!(param.ordinal_position, 1);
+    }
+
+    // ===== Volatility tests =====
+
+    #[test]
+    fn test_volatility_display_immutable() {
+        assert_eq!(Volatility::Immutable.to_string(), "IMMUTABLE");
+    }
+
+    #[test]
+    fn test_volatility_display_stable() {
+        assert_eq!(Volatility::Stable.to_string(), "STABLE");
+    }
+
+    #[test]
+    fn test_volatility_display_volatile() {
+        assert_eq!(Volatility::Volatile.to_string(), "VOLATILE");
+    }
+
+    // ===== Routine struct tests =====
+
+    #[test]
+    fn test_routine_new_function() {
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "plpgsql");
+
+        assert_eq!(routine.name, "get_user");
+        assert_eq!(routine.schema, "public");
+        assert_eq!(routine.routine_type, RoutineType::Function);
+        assert_eq!(routine.language, "plpgsql");
+        assert!(routine.parameters.is_empty());
+        assert!(routine.return_type.is_none());
+        assert_eq!(routine.volatility, Volatility::Volatile);
+        assert!(!routine.security_definer);
+        assert!(routine.definition.is_none());
+        assert!(routine.comment.is_none());
+    }
+
+    #[test]
+    fn test_routine_new_procedure() {
+        let routine = Routine::new("update_user", "public", RoutineType::Procedure, "plpgsql");
+
+        assert_eq!(routine.routine_type, RoutineType::Procedure);
+    }
+
+    #[test]
+    fn test_routine_with_parameter() {
+        let param = RoutineParameter::new("user_id", "integer", ParameterMode::In);
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "plpgsql")
+            .with_parameter(param);
+
+        assert_eq!(routine.parameters.len(), 1);
+        assert_eq!(routine.parameters[0].name, "user_id");
+    }
+
+    #[test]
+    fn test_routine_with_multiple_parameters() {
+        let params = vec![
+            RoutineParameter::new("user_id", "integer", ParameterMode::In),
+            RoutineParameter::new("user_name", "text", ParameterMode::In),
+        ];
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "plpgsql")
+            .with_parameters(params);
+
+        assert_eq!(routine.parameters.len(), 2);
+    }
+
+    #[test]
+    fn test_routine_with_return_type() {
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "plpgsql")
+            .with_return_type("SETOF users");
+
+        assert_eq!(routine.return_type, Some("SETOF users".to_string()));
+    }
+
+    #[test]
+    fn test_routine_with_volatility() {
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "plpgsql")
+            .with_volatility(Volatility::Stable);
+
+        assert_eq!(routine.volatility, Volatility::Stable);
+    }
+
+    #[test]
+    fn test_routine_with_security_definer() {
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "plpgsql")
+            .with_security_definer(true);
+
+        assert!(routine.security_definer);
+    }
+
+    #[test]
+    fn test_routine_with_definition() {
+        let definition =
+            "CREATE FUNCTION get_user(id integer) RETURNS users AS $$ SELECT * FROM users WHERE id = $1 $$ LANGUAGE sql";
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "sql")
+            .with_definition(definition);
+
+        assert_eq!(routine.definition, Some(definition.to_string()));
+    }
+
+    #[test]
+    fn test_routine_with_comment() {
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "plpgsql")
+            .with_comment("Retrieves a user by ID");
+
+        assert_eq!(
+            routine.comment,
+            Some("Retrieves a user by ID".to_string())
+        );
+    }
+
+    #[test]
+    fn test_routine_qualified_name() {
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "plpgsql");
+
+        assert_eq!(routine.qualified_name(), "public.get_user");
+    }
+
+    #[test]
+    fn test_routine_parameters_signature_empty() {
+        let routine = Routine::new("get_all_users", "public", RoutineType::Function, "sql");
+
+        assert_eq!(routine.parameters_signature(), "()");
+    }
+
+    #[test]
+    fn test_routine_parameters_signature_single() {
+        let routine = Routine::new("get_user", "public", RoutineType::Function, "sql")
+            .with_parameter(RoutineParameter::new("user_id", "integer", ParameterMode::In));
+
+        assert_eq!(routine.parameters_signature(), "(user_id integer)");
+    }
+
+    #[test]
+    fn test_routine_parameters_signature_multiple() {
+        let routine = Routine::new("get_users", "public", RoutineType::Function, "sql")
+            .with_parameter(RoutineParameter::new("offset_val", "integer", ParameterMode::In))
+            .with_parameter(RoutineParameter::new("limit_val", "integer", ParameterMode::In));
+
+        assert_eq!(
+            routine.parameters_signature(),
+            "(offset_val integer, limit_val integer)"
+        );
+    }
+
+    #[test]
+    fn test_routine_parameters_signature_excludes_out_params() {
+        let routine = Routine::new("get_user_with_count", "public", RoutineType::Function, "sql")
+            .with_parameter(RoutineParameter::new("user_id", "integer", ParameterMode::In))
+            .with_parameter(RoutineParameter::new("total_count", "integer", ParameterMode::Out));
+
+        assert_eq!(routine.parameters_signature(), "(user_id integer)");
+    }
+
+    #[test]
+    fn test_routine_parameters_signature_unnamed() {
+        let routine = Routine::new("add_numbers", "public", RoutineType::Function, "sql")
+            .with_parameter(RoutineParameter::new("", "integer", ParameterMode::In))
+            .with_parameter(RoutineParameter::new("", "integer", ParameterMode::In));
+
+        assert_eq!(routine.parameters_signature(), "(integer, integer)");
+    }
+
+    #[test]
+    fn test_routine_is_function() {
+        let func = Routine::new("get_user", "public", RoutineType::Function, "sql");
+        let proc = Routine::new("update_user", "public", RoutineType::Procedure, "sql");
+
+        assert!(func.is_function());
+        assert!(!func.is_procedure());
+        assert!(!proc.is_function());
+        assert!(proc.is_procedure());
+    }
+
+    // ===== Full builder pattern test =====
+
+    #[test]
+    fn test_routine_full_builder() {
+        let routine = Routine::new("calculate_total", "billing", RoutineType::Function, "plpgsql")
+            .with_parameters(vec![
+                RoutineParameter::new("order_id", "integer", ParameterMode::In).with_position(1),
+                RoutineParameter::new("include_tax", "boolean", ParameterMode::In)
+                    .with_default("true")
+                    .with_position(2),
+            ])
+            .with_return_type("numeric")
+            .with_volatility(Volatility::Stable)
+            .with_security_definer(false)
+            .with_definition("CREATE FUNCTION calculate_total...")
+            .with_comment("Calculates the total amount for an order");
+
+        assert_eq!(routine.name, "calculate_total");
+        assert_eq!(routine.schema, "billing");
+        assert!(routine.is_function());
+        assert_eq!(routine.parameters.len(), 2);
+        assert_eq!(routine.return_type, Some("numeric".to_string()));
+        assert_eq!(routine.volatility, Volatility::Stable);
+        assert!(!routine.security_definer);
+        assert!(routine.definition.is_some());
+        assert!(routine.comment.is_some());
+        assert_eq!(
+            routine.parameters_signature(),
+            "(order_id integer, include_tax boolean)"
+        );
+    }
+}

--- a/src/ui/panel/mod.rs
+++ b/src/ui/panel/mod.rs
@@ -1,10 +1,12 @@
 //! Main panel rendering
 //!
 //! This module handles the main content panel including Schema, Data, and Relations tabs.
+//! When a routine (stored procedure/function) is selected, it displays the routine details instead.
 
 mod data_tab;
 mod query_editor;
 mod relations_tab;
+mod routine_tab;
 mod schema_tab;
 
 use crate::app::{App, Focus, MainPanelTab};
@@ -25,6 +27,20 @@ pub fn draw_panel(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         theme::border_inactive()
     };
+
+    // Check if a routine is selected - if so, show routine detail view instead of tabs
+    if app.selected_routine_info().is_some() {
+        let content_block = Block::default()
+            .title(" Routine Details ")
+            .borders(Borders::ALL)
+            .border_style(border_style);
+
+        let inner_area = content_block.inner(area);
+        frame.render_widget(content_block, area);
+
+        routine_tab::draw_routine_content(frame, app, inner_area);
+        return;
+    }
 
     // Split area for tabs and content
     let chunks = Layout::default()

--- a/src/ui/panel/routine_tab.rs
+++ b/src/ui/panel/routine_tab.rs
@@ -23,11 +23,21 @@ pub fn draw_routine_content(frame: &mut Frame, app: &App, area: Rect) {
         return;
     };
 
+    // Calculate header height dynamically based on content
+    // Base: 2 lines (name + type)
+    let mut header_height: u16 = 2;
+    if routine.is_function() {
+        header_height += 1; // Returns line
+    }
+    if !routine.language.is_empty() {
+        header_height += 1; // Language line
+    }
+
     // Split area: header + parameters + definition
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(4),  // Header (name, type, return)
+            Constraint::Length(header_height),
             Constraint::Length(8),  // Parameters table
             Constraint::Min(5),     // Definition
         ])

--- a/src/ui/panel/routine_tab.rs
+++ b/src/ui/panel/routine_tab.rs
@@ -1,0 +1,167 @@
+//! Routine detail view for stored procedures and functions
+//!
+//! Displays routine definition, parameters, and return type information.
+
+use crate::app::App;
+use crate::model::schema::Routine;
+use crate::ui::theme;
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::Modifier,
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Row, Table},
+    Frame,
+};
+
+/// Draw routine details when a routine is selected
+pub fn draw_routine_content(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(routine) = app.selected_routine_info() else {
+        let msg = Paragraph::new("No routine selected")
+            .style(theme::muted())
+            .block(Block::default().borders(Borders::NONE));
+        frame.render_widget(msg, area);
+        return;
+    };
+
+    // Split area: header + parameters + definition
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),  // Header (name, type, return)
+            Constraint::Length(8),  // Parameters table
+            Constraint::Min(5),     // Definition
+        ])
+        .split(area);
+
+    draw_routine_header(frame, routine, chunks[0]);
+    draw_parameters_section(frame, routine, chunks[1]);
+    draw_definition_section(frame, routine, chunks[2]);
+}
+
+/// Draw routine header with name, type, and return type
+fn draw_routine_header(frame: &mut Frame, routine: &Routine, area: Rect) {
+    let routine_type = if routine.is_function() {
+        "Function"
+    } else {
+        "Procedure"
+    };
+    let icon = if routine.is_function() { "ƒ" } else { "⚙" };
+
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled(format!("{} ", icon), theme::header()),
+            Span::styled(
+                routine.qualified_name(),
+                theme::text().add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Type: ", theme::muted()),
+            Span::styled(routine_type, theme::text()),
+        ]),
+    ];
+
+    // Return type (for functions)
+    if routine.is_function() {
+        let return_type = routine
+            .return_type
+            .as_deref()
+            .unwrap_or("unknown");
+        lines.push(Line::from(vec![
+            Span::styled("Returns: ", theme::muted()),
+            Span::styled(return_type, theme::selected()),
+        ]));
+    }
+
+    // Language
+    if !routine.language.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("Language: ", theme::muted()),
+            Span::styled(&routine.language, theme::text()),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, area);
+}
+
+/// Draw parameters table
+fn draw_parameters_section(frame: &mut Frame, routine: &Routine, area: Rect) {
+    let block = Block::default()
+        .title(" Parameters ")
+        .borders(Borders::ALL)
+        .border_style(theme::border_inactive());
+
+    let inner_area = block.inner(area);
+    frame.render_widget(block, area);
+
+    if routine.parameters.is_empty() {
+        let msg = Paragraph::new("No parameters").style(theme::muted());
+        frame.render_widget(msg, inner_area);
+        return;
+    }
+
+    // Build table rows
+    let rows: Vec<Row> = routine
+        .parameters
+        .iter()
+        .map(|param| {
+            let mode_str = param.mode.to_string();
+            let default_str = param
+                .default_value
+                .as_ref()
+                .map(|d| format!(" = {}", d))
+                .unwrap_or_default();
+
+            Row::new(vec![
+                param.name.clone(),
+                param.data_type.clone(),
+                mode_str,
+                default_str,
+            ])
+            .style(theme::text())
+        })
+        .collect();
+
+    let header = Row::new(vec!["Name", "Type", "Mode", "Default"])
+        .style(theme::header())
+        .bottom_margin(1);
+
+    let widths = [
+        Constraint::Percentage(30),
+        Constraint::Percentage(30),
+        Constraint::Percentage(15),
+        Constraint::Percentage(25),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(theme::focused());
+
+    frame.render_widget(table, inner_area);
+}
+
+/// Draw routine definition (source code)
+fn draw_definition_section(frame: &mut Frame, routine: &Routine, area: Rect) {
+    let block = Block::default()
+        .title(" Definition ")
+        .borders(Borders::ALL)
+        .border_style(theme::border_inactive());
+
+    let inner_area = block.inner(area);
+    frame.render_widget(block, area);
+
+    let definition = routine
+        .definition
+        .as_deref()
+        .unwrap_or("-- Definition not available");
+
+    // Split definition into lines for proper display
+    let lines: Vec<Line> = definition
+        .lines()
+        .map(|line| Line::from(Span::styled(line, theme::text())))
+        .collect();
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner_area);
+}

--- a/src/ui/panel/routine_tab.rs
+++ b/src/ui/panel/routine_tab.rs
@@ -38,8 +38,8 @@ pub fn draw_routine_content(frame: &mut Frame, app: &App, area: Rect) {
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(header_height),
-            Constraint::Length(8),  // Parameters table
-            Constraint::Min(5),     // Definition
+            Constraint::Length(8), // Parameters table
+            Constraint::Min(5),    // Definition
         ])
         .split(area);
 
@@ -73,10 +73,7 @@ fn draw_routine_header(frame: &mut Frame, routine: &Routine, area: Rect) {
 
     // Return type (for functions)
     if routine.is_function() {
-        let return_type = routine
-            .return_type
-            .as_deref()
-            .unwrap_or("unknown");
+        let return_type = routine.return_type.as_deref().unwrap_or("unknown");
         lines.push(Line::from(vec![
             Span::styled("Returns: ", theme::muted()),
             Span::styled(return_type, theme::selected()),

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -179,7 +179,8 @@ fn draw_connections_view(frame: &mut Frame, app: &App, area: Rect, proj_idx: usi
             // Draw tables
             for (table_idx, table) in conn.tables.iter().enumerate() {
                 let is_selected_table = conn_idx == app.selected_connection_idx
-                    && app.selected_table_idx == Some(table_idx);
+                    && app.selected_table_idx == Some(table_idx)
+                    && app.selected_routine_idx.is_none();
 
                 let table_style = if is_selected_table && is_focused {
                     theme::focused()
@@ -220,7 +221,8 @@ fn draw_connections_view(frame: &mut Frame, app: &App, area: Rect, proj_idx: usi
             // Draw routines (stored procedures and functions)
             for (routine_idx, routine) in conn.routines.iter().enumerate() {
                 let is_selected_routine = conn_idx == app.selected_connection_idx
-                    && app.selected_routine_idx == Some(routine_idx);
+                    && app.selected_routine_idx == Some(routine_idx)
+                    && app.selected_table_idx.is_none();
 
                 let routine_style = if is_selected_routine && is_focused {
                     theme::focused()

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -154,8 +154,9 @@ fn draw_connections_view(frame: &mut Frame, app: &App, area: Rect, proj_idx: usi
         .unwrap_or(&[]);
 
     for (conn_idx, conn) in connections.iter().enumerate() {
-        let is_selected_conn =
-            conn_idx == app.selected_connection_idx && app.selected_table_idx.is_none();
+        let is_selected_conn = conn_idx == app.selected_connection_idx
+            && app.selected_table_idx.is_none()
+            && app.selected_routine_idx.is_none();
         let expand_icon = if conn.expanded { "▼" } else { "▶" };
 
         let conn_style = if is_selected_conn && is_focused {
@@ -172,6 +173,10 @@ fn draw_connections_view(frame: &mut Frame, app: &App, area: Rect, proj_idx: usi
         ]));
 
         if conn.expanded {
+            let total_items = conn.tables.len() + conn.routines.len();
+            let mut item_idx = 0;
+
+            // Draw tables
             for (table_idx, table) in conn.tables.iter().enumerate() {
                 let is_selected_table = conn_idx == app.selected_connection_idx
                     && app.selected_table_idx == Some(table_idx);
@@ -188,7 +193,8 @@ fn draw_connections_view(frame: &mut Frame, app: &App, area: Rect, proj_idx: usi
                 // Icon style matches table style for consistency
                 let icon_style = table_style;
 
-                let prefix = if table_idx == conn.tables.len() - 1 {
+                item_idx += 1;
+                let prefix = if item_idx == total_items {
                     "  └─ "
                 } else {
                     "  ├─ "
@@ -205,6 +211,44 @@ fn draw_connections_view(frame: &mut Frame, app: &App, area: Rect, proj_idx: usi
 
                 // If table is selected and focused, apply background to entire line
                 if is_selected_table && is_focused {
+                    lines.push(line.style(theme::focused()));
+                } else {
+                    lines.push(line);
+                }
+            }
+
+            // Draw routines (stored procedures and functions)
+            for (routine_idx, routine) in conn.routines.iter().enumerate() {
+                let is_selected_routine = conn_idx == app.selected_connection_idx
+                    && app.selected_routine_idx == Some(routine_idx);
+
+                let routine_style = if is_selected_routine && is_focused {
+                    theme::focused()
+                } else if is_selected_routine {
+                    theme::text().add_modifier(Modifier::BOLD)
+                } else {
+                    theme::muted()
+                };
+
+                let icon_style = routine_style;
+
+                item_idx += 1;
+                let prefix = if item_idx == total_items {
+                    "  └─ "
+                } else {
+                    "  ├─ "
+                };
+
+                // Icon: ƒ for functions, ⚙ for procedures
+                let icon = if routine.is_function() { "ƒ" } else { "⚙" };
+
+                let line = Line::from(vec![
+                    Span::styled(prefix, theme::muted()),
+                    Span::styled(format!("{} ", icon), icon_style),
+                    Span::styled(&routine.name, routine_style),
+                ]);
+
+                if is_selected_routine && is_focused {
                     lines.push(line.style(theme::focused()));
                 } else {
                     lines.push(line);
@@ -230,7 +274,70 @@ pub fn draw_table_summary(frame: &mut Frame, app: &App, area: Rect) {
     let inner_area = block.inner(area);
     frame.render_widget(block, area);
 
-    let lines = if let Some(table) = app.selected_table_info() {
+    let lines = if let Some(routine) = app.selected_routine_info() {
+        // Routine selected - show routine info
+        let routine_type = if routine.is_function() {
+            "Function"
+        } else {
+            "Procedure"
+        };
+        let icon = if routine.is_function() { "ƒ" } else { "⚙" };
+
+        let mut info_lines = vec![
+            Line::from(vec![
+                Span::styled(format!("{} ", icon), theme::header()),
+                Span::styled(
+                    &routine.name,
+                    Style::default()
+                        .fg(theme::ACCENT)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(vec![Span::styled(routine_type, theme::muted())]),
+        ];
+
+        // Show schema
+        if !routine.schema.is_empty() {
+            info_lines.push(Line::from(vec![
+                Span::styled("Schema: ", theme::muted()),
+                Span::styled(&routine.schema, theme::text()),
+            ]));
+        }
+
+        // Show return type for functions
+        if routine.is_function() {
+            if let Some(return_type) = &routine.return_type {
+                info_lines.push(Line::from(vec![
+                    Span::styled("Returns: ", theme::muted()),
+                    Span::styled(return_type, theme::selected()),
+                ]));
+            }
+        }
+
+        // Show parameter count
+        let param_count = routine.parameters.len();
+        if param_count > 0 {
+            info_lines.push(Line::from(vec![Span::styled(
+                format!("{} parameter(s)", param_count),
+                theme::muted(),
+            )]));
+        } else {
+            info_lines.push(Line::from(vec![Span::styled(
+                "No parameters",
+                theme::muted(),
+            )]));
+        }
+
+        // Show language
+        if !routine.language.is_empty() {
+            info_lines.push(Line::from(vec![
+                Span::styled("Language: ", theme::muted()),
+                Span::styled(&routine.language, theme::text()),
+            ]));
+        }
+
+        info_lines
+    } else if let Some(table) = app.selected_table_info() {
         let pk_name = table
             .columns
             .iter()


### PR DESCRIPTION
## Summary
- サイドバーにストアドプロシージャ・関数を一覧表示する機能を追加
- ルーティン選択時にパラメータ情報・戻り値型・定義コードを詳細パネルに表示
- PostgreSQL の pg_proc カタログからルーティン情報を取得

## Changes
### 新規ファイル
- `src/model/schema/routine.rs` - Routine/RoutineParameter モデル定義
- `src/db/postgres/queries/routines.rs` - PostgreSQL ルーティン取得クエリ
- `src/ui/panel/routine_tab.rs` - ルーティン詳細表示UI

### 主な変更
- サイドバーにルーティン表示（ƒ=関数, ⚙=プロシージャ）
- Info パネルでルーティン概要表示
- メインパネルでパラメータ一覧と定義コード表示
- 接続展開時にテーブルとルーティンを並行取得
- ナビゲーションロジックをルーティン対応に拡張

## Test plan
- [x] `cargo test` - 218テスト全て成功
- [x] `cargo clippy` - 警告なし
- [ ] PostgreSQL に接続して関数・プロシージャが表示されることを確認
- [ ] ルーティン選択時に詳細パネルが正しく表示されることを確認