### PR TITLE
feat: ✨ implement connection editing functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -300,3 +300,9 @@ $RECYCLE.BIN/
 
 # Serena MCP settings
 .serena/
+
+# Claude Code auto-generated CLAUDE.md in subdirectories (not tracked)
+**/CLAUDE.md
+
+# Worktree artifacts
+lazydb/

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,6 @@
 {
   // Ignore patterns
-  "ignores": [".claude/**", "node_modules/**", "target/**"],
+  "ignores": [".claude/**", "node_modules/**", "target/**", "**/CLAUDE.md", "lazydb/**"],
 
   // Config for markdownlint
   "config": {

--- a/src/app/handlers/modal.rs
+++ b/src/app/handlers/modal.rs
@@ -14,19 +14,21 @@ impl App {
     /// Handle character input for modals
     pub(crate) fn handle_modal_input_char(&mut self, c: char) {
         match &mut self.modal_state {
-            ModalState::AddConnection(modal) => match modal.focused_field {
-                ConnectionModalField::Name => modal.name.push(c),
-                ConnectionModalField::Host => modal.host.push(c),
-                ConnectionModalField::Port => {
-                    if c.is_ascii_digit() && modal.port.len() < 5 {
-                        modal.port.push(c);
+            ModalState::AddConnection(modal) | ModalState::EditConnection(_, modal) => {
+                match modal.focused_field {
+                    ConnectionModalField::Name => modal.name.push(c),
+                    ConnectionModalField::Host => modal.host.push(c),
+                    ConnectionModalField::Port => {
+                        if c.is_ascii_digit() && modal.port.len() < 5 {
+                            modal.port.push(c);
+                        }
                     }
+                    ConnectionModalField::User => modal.user.push(c),
+                    ConnectionModalField::Password => modal.password.push(c),
+                    ConnectionModalField::Database => modal.database.push(c),
+                    ConnectionModalField::ButtonOk | ConnectionModalField::ButtonCancel => {}
                 }
-                ConnectionModalField::User => modal.user.push(c),
-                ConnectionModalField::Password => modal.password.push(c),
-                ConnectionModalField::Database => modal.database.push(c),
-                ConnectionModalField::ButtonOk | ConnectionModalField::ButtonCancel => {}
-            },
+            }
             ModalState::AddProject(modal) | ModalState::EditProject(_, modal) => {
                 if modal.focused_field == ProjectModalField::Name {
                     modal.name.push(c);
@@ -81,27 +83,29 @@ impl App {
     /// Handle backspace for modals
     pub(crate) fn handle_modal_backspace(&mut self) {
         match &mut self.modal_state {
-            ModalState::AddConnection(modal) => match modal.focused_field {
-                ConnectionModalField::Name => {
-                    modal.name.pop();
+            ModalState::AddConnection(modal) | ModalState::EditConnection(_, modal) => {
+                match modal.focused_field {
+                    ConnectionModalField::Name => {
+                        modal.name.pop();
+                    }
+                    ConnectionModalField::Host => {
+                        modal.host.pop();
+                    }
+                    ConnectionModalField::Port => {
+                        modal.port.pop();
+                    }
+                    ConnectionModalField::User => {
+                        modal.user.pop();
+                    }
+                    ConnectionModalField::Password => {
+                        modal.password.pop();
+                    }
+                    ConnectionModalField::Database => {
+                        modal.database.pop();
+                    }
+                    ConnectionModalField::ButtonOk | ConnectionModalField::ButtonCancel => {}
                 }
-                ConnectionModalField::Host => {
-                    modal.host.pop();
-                }
-                ConnectionModalField::Port => {
-                    modal.port.pop();
-                }
-                ConnectionModalField::User => {
-                    modal.user.pop();
-                }
-                ConnectionModalField::Password => {
-                    modal.password.pop();
-                }
-                ConnectionModalField::Database => {
-                    modal.database.pop();
-                }
-                ConnectionModalField::ButtonOk | ConnectionModalField::ButtonCancel => {}
-            },
+            }
             ModalState::AddProject(modal) | ModalState::EditProject(_, modal) => {
                 if modal.focused_field == ProjectModalField::Name {
                     modal.name.pop();
@@ -156,7 +160,7 @@ impl App {
     /// Handle modal next field navigation
     pub(crate) fn handle_modal_next_field(&mut self) {
         match &mut self.modal_state {
-            ModalState::AddConnection(modal) => {
+            ModalState::AddConnection(modal) | ModalState::EditConnection(_, modal) => {
                 modal.focused_field = modal.focused_field.next();
             }
             ModalState::AddProject(modal) | ModalState::EditProject(_, modal) => {
@@ -187,7 +191,7 @@ impl App {
     /// Handle modal prev field navigation
     pub(crate) fn handle_modal_prev_field(&mut self) {
         match &mut self.modal_state {
-            ModalState::AddConnection(modal) => {
+            ModalState::AddConnection(modal) | ModalState::EditConnection(_, modal) => {
                 modal.focused_field = modal.focused_field.prev();
             }
             ModalState::AddProject(modal) | ModalState::EditProject(_, modal) => {
@@ -233,6 +237,29 @@ impl App {
                         "Invalid: fill name, host, user, database and valid port (1-65535)"
                             .to_string();
                     // Keep modal open for user to correct input
+                }
+            }
+            ModalState::EditConnection(conn_idx, modal) => {
+                if let Some(conn) = self.create_connection_from_modal(modal) {
+                    let conn_idx = *conn_idx;
+                    if let SidebarMode::Connections(proj_idx) = self.sidebar_mode {
+                        if let Some(project) = self.projects.get_mut(proj_idx) {
+                            if let Some(existing) = project.connections.get_mut(conn_idx) {
+                                existing.name = conn.name;
+                                existing.host = conn.host;
+                                existing.port = conn.port;
+                                existing.database = conn.database;
+                                existing.username = conn.username;
+                                existing.password = conn.password;
+                                self.status_message = "Connection updated".to_string();
+                            }
+                        }
+                    }
+                    self.modal_state = ModalState::None;
+                } else {
+                    self.status_message =
+                        "Invalid: fill name, host, user, database and valid port (1-65535)"
+                            .to_string();
                 }
             }
             ModalState::AddProject(modal) => {

--- a/src/app/modals/connection.rs
+++ b/src/app/modals/connection.rs
@@ -27,3 +27,18 @@ impl Default for AddConnectionModal {
         }
     }
 }
+
+impl AddConnectionModal {
+    /// Create a modal pre-filled with existing connection data (for editing)
+    pub fn from_connection(conn: &crate::model::Connection) -> Self {
+        Self {
+            name: conn.name.clone(),
+            host: conn.host.clone(),
+            port: conn.port.to_string(),
+            user: conn.username.clone(),
+            password: conn.password.clone(),
+            database: conn.database.clone(),
+            focused_field: ConnectionModalField::Name,
+        }
+    }
+}

--- a/src/app/modals/state.rs
+++ b/src/app/modals/state.rs
@@ -12,6 +12,7 @@ use super::visibility::ColumnVisibilityModal;
 pub enum ModalState {
     None,
     AddConnection(AddConnectionModal),
+    EditConnection(usize, AddConnectionModal), // (connection index, modal)
     AddProject(ProjectModal),
     EditProject(usize, ProjectModal), // (project index, modal)
     DeleteProject(DeleteProjectModal),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -285,6 +285,10 @@ impl App {
             Message::OpenAddConnectionModal => {
                 self.modal_state = ModalState::AddConnection(AddConnectionModal::default());
             }
+            Message::OpenEditConnectionModal => {
+                // TODO: Implement connection editing modal
+                // This is a placeholder to make the tests compile
+            }
             Message::OpenAddProjectModal => {
                 self.modal_state = ModalState::AddProject(ProjectModal::default());
             }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -288,9 +288,7 @@ impl App {
             Message::OpenEditConnectionModal => {
                 if let SidebarMode::Connections(proj_idx) = self.sidebar_mode {
                     if let Some(project) = self.projects.get(proj_idx) {
-                        if let Some(conn) =
-                            project.connections.get(self.selected_connection_idx)
-                        {
+                        if let Some(conn) = project.connections.get(self.selected_connection_idx) {
                             self.modal_state = ModalState::EditConnection(
                                 self.selected_connection_idx,
                                 AddConnectionModal::from_connection(conn),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -286,8 +286,18 @@ impl App {
                 self.modal_state = ModalState::AddConnection(AddConnectionModal::default());
             }
             Message::OpenEditConnectionModal => {
-                // TODO: Implement connection editing modal
-                // This is a placeholder to make the tests compile
+                if let SidebarMode::Connections(proj_idx) = self.sidebar_mode {
+                    if let Some(project) = self.projects.get(proj_idx) {
+                        if let Some(conn) =
+                            project.connections.get(self.selected_connection_idx)
+                        {
+                            self.modal_state = ModalState::EditConnection(
+                                self.selected_connection_idx,
+                                AddConnectionModal::from_connection(conn),
+                            );
+                        }
+                    }
+                }
             }
             Message::OpenAddProjectModal => {
                 self.modal_state = ModalState::AddProject(ProjectModal::default());

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -5,6 +5,9 @@
 mod modal;
 mod normal;
 
+#[cfg(test)]
+mod tests;
+
 use crossterm::event::KeyCode;
 
 use crate::app::App;

--- a/src/event/modal.rs
+++ b/src/event/modal.rs
@@ -19,7 +19,9 @@ pub fn handle_modal_input(
 ) -> Option<Message> {
     match &app.modal_state {
         ModalState::None => None,
-        ModalState::AddConnection(modal) => handle_connection_modal(key_code, modal),
+        ModalState::AddConnection(modal) | ModalState::EditConnection(_, modal) => {
+            handle_connection_modal(key_code, modal)
+        }
         ModalState::AddProject(modal) | ModalState::EditProject(_, modal) => {
             handle_project_modal(key_code, modal)
         }

--- a/src/event/normal.rs
+++ b/src/event/normal.rs
@@ -89,11 +89,17 @@ pub fn handle_normal_input(
             SidebarMode::Connections(_) => Some(Message::OpenAddConnectionModal),
         },
 
-        // Project edit: 'e' key in Projects view
+        // Edit: 'e' key in sidebar (Project or Connection depending on mode)
         (KeyCode::Char('e'), _)
             if app.focus == Focus::Sidebar && matches!(app.sidebar_mode, SidebarMode::Projects) =>
         {
             Some(Message::OpenEditProjectModal)
+        }
+        (KeyCode::Char('e'), _)
+            if app.focus == Focus::Sidebar
+                && matches!(app.sidebar_mode, SidebarMode::Connections(_)) =>
+        {
+            Some(Message::OpenEditConnectionModal)
         }
 
         // Project delete: 'd' key in Projects view

--- a/src/event/tests.rs
+++ b/src/event/tests.rs
@@ -23,6 +23,8 @@ fn create_test_app_with_connections() -> App {
         password: "pass".to_string(),
         expanded: false,
         tables: vec![],
+        routines: vec![],
+        routines_loaded: false,
     });
 
     let mut app = App::new(vec![project]);

--- a/src/event/tests.rs
+++ b/src/event/tests.rs
@@ -1,0 +1,91 @@
+//! Tests for event handling
+//!
+//! This module contains tests for keyboard event handling,
+//! including connection editing functionality.
+
+use crossterm::event::{KeyCode, KeyModifiers};
+
+use crate::app::{App, Focus, SidebarMode};
+use crate::message::Message;
+use crate::model::{Connection, Project};
+
+use super::handle_normal_input;
+
+/// Helper function to create an App with test data
+fn create_test_app_with_connections() -> App {
+    let mut project = Project::new("Test Project");
+    project.connections.push(Connection {
+        name: "test-conn".to_string(),
+        host: "localhost".to_string(),
+        port: 5432,
+        database: "testdb".to_string(),
+        username: "user".to_string(),
+        password: "pass".to_string(),
+        expanded: false,
+        tables: vec![],
+    });
+
+    let mut app = App::new(vec![project]);
+    // Navigate into connections mode
+    app.sidebar_mode = SidebarMode::Connections(0);
+    app.selected_connection_idx = 0;
+    app.focus = Focus::Sidebar;
+    app
+}
+
+// =============================================================================
+// Connection Edit Tests
+// =============================================================================
+
+#[test]
+fn test_edit_connection_key_opens_modal_in_connections_mode() {
+    // Given: App is in Connections mode with sidebar focused
+    let app = create_test_app_with_connections();
+    assert!(matches!(app.sidebar_mode, SidebarMode::Connections(_)));
+    assert_eq!(app.focus, Focus::Sidebar);
+
+    // When: User presses 'e' key
+    let result = handle_normal_input(&app, KeyCode::Char('e'), KeyModifiers::NONE);
+
+    // Then: OpenEditConnectionModal message should be returned
+    assert_eq!(result, Some(Message::OpenEditConnectionModal));
+}
+
+#[test]
+fn test_edit_connection_key_does_not_open_modal_in_projects_mode() {
+    // Given: App is in Projects mode
+    let mut app = create_test_app_with_connections();
+    app.sidebar_mode = SidebarMode::Projects;
+
+    // When: User presses 'e' key
+    let result = handle_normal_input(&app, KeyCode::Char('e'), KeyModifiers::NONE);
+
+    // Then: OpenEditProjectModal should be returned (not connection)
+    assert_eq!(result, Some(Message::OpenEditProjectModal));
+}
+
+#[test]
+fn test_edit_connection_key_does_nothing_when_main_panel_focused() {
+    // Given: App is in Connections mode but MainPanel is focused
+    let mut app = create_test_app_with_connections();
+    app.focus = Focus::MainPanel;
+
+    // When: User presses 'e' key
+    let result = handle_normal_input(&app, KeyCode::Char('e'), KeyModifiers::NONE);
+
+    // Then: No message should be returned (key not handled)
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_edit_connection_key_does_nothing_when_query_editor_focused() {
+    // Given: App is in Connections mode but QueryEditor is focused
+    let mut app = create_test_app_with_connections();
+    app.focus = Focus::QueryEditor;
+
+    // When: User presses 'e' key
+    let result = handle_normal_input(&app, KeyCode::Char('e'), KeyModifiers::NONE);
+
+    // Then: No message should be returned (key not handled)
+    assert_eq!(result, None);
+}

--- a/src/message.rs
+++ b/src/message.rs
@@ -42,6 +42,7 @@ pub enum Message {
     SwitchToDefinition,
     // Connection modal messages
     OpenAddConnectionModal,
+    OpenEditConnectionModal,
     // Project modal messages
     OpenAddProjectModal,
     OpenEditProjectModal,

--- a/src/ui/modal/connection_modal.rs
+++ b/src/ui/modal/connection_modal.rs
@@ -11,7 +11,7 @@ use ratatui::{
 
 use super::helpers::{centered_rect, draw_input_field};
 
-pub fn draw_add_connection_modal(frame: &mut Frame, modal: &AddConnectionModal) {
+pub fn draw_connection_modal(frame: &mut Frame, modal: &AddConnectionModal, title: &str) {
     let area = centered_rect(50, 70, frame.area());
 
     // Clear the area behind the modal
@@ -19,7 +19,7 @@ pub fn draw_add_connection_modal(frame: &mut Frame, modal: &AddConnectionModal) 
 
     // Modal container
     let block = Block::default()
-        .title(" Add Connection ")
+        .title(title)
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_style(theme::border_focused());

--- a/src/ui/modal/mod.rs
+++ b/src/ui/modal/mod.rs
@@ -30,7 +30,10 @@ pub fn draw_modal(
     match modal_state {
         ModalState::None => {}
         ModalState::AddConnection(modal) => {
-            connection_modal::draw_add_connection_modal(frame, modal);
+            connection_modal::draw_connection_modal(frame, modal, " Add Connection ");
+        }
+        ModalState::EditConnection(_, modal) => {
+            connection_modal::draw_connection_modal(frame, modal, " Edit Connection ");
         }
         ModalState::AddProject(modal) => {
             project_modal::draw_project_modal(frame, modal, " Add Project ");


### PR DESCRIPTION
## Summary

- サイドバーの Connections モードで `e` キーを押すと、既存コネクションの編集モーダルが開く機能を追加
- `EditProject` と同じパターンで `EditConnection` を実装し、既存の `AddConnectionModal` を再利用
- TDD で開発: テスト作成 → 失敗確認 → 実装 → 全テスト通過

## Changes

- `Message::OpenEditConnectionModal` メッセージ追加
- `ModalState::EditConnection(usize, AddConnectionModal)` バリアント追加
- `AddConnectionModal::from_connection()` コンストラクタ追加（既存値でプリフィル）
- `e` キーで Connections モード時に編集モーダルを開くキーバインド追加
- モーダルの入力・バックスペース・フィールド移動・確認ハンドラに `EditConnection` 対応追加
- UI レンダリングで "Edit Connection" タイトル表示

## Test plan

- [x] `test_edit_connection_key_opens_modal_in_connections_mode` — Connections モードで `e` キーが `OpenEditConnectionModal` を返す
- [x] `test_edit_connection_key_does_not_open_modal_in_projects_mode` — Projects モードでは `OpenEditProjectModal` が返る
- [x] `test_edit_connection_key_does_nothing_when_main_panel_focused` — MainPanel フォーカス時は無視される
- [x] `test_edit_connection_key_does_nothing_when_query_editor_focused` — QueryEditor フォーカス時は無視される
- [x] 全 256 テスト通過確認済み
- [ ] 手動テスト: アプリを起動し、Connections モードで `e` キーを押して編集モーダルが既存値で表示されることを確認
- [ ] 手動テスト: 値を変更して確定後、コネクション情報が更新されることを確認